### PR TITLE
fix: убрано ограничение контента при развернутом окне редактора BUGS-…

### DIFF
--- a/src/components/dialogs/IssueDialogs/CommentShowDialog.vue
+++ b/src/components/dialogs/IssueDialogs/CommentShowDialog.vue
@@ -204,7 +204,7 @@ const onHide = async () => {
 .issue-comment__editor {
   :deep(.html-editor__container) {
     min-height: 25rem;
-    height: 25rem;
+    height: 100%;
   }
   :deep(.tiptap) {
     min-height: 25rem;

--- a/src/css/editor.scss
+++ b/src/css/editor.scss
@@ -143,7 +143,7 @@
     border-bottom-left-radius: 8px;
     border-bottom-right-radius: 8px;
     min-height: 25rem;
-    height: 25rem;
+    height: 100%;
   }
 
   .tiptap {


### PR DESCRIPTION
Убрал жесткую высоту для контента в редакторе при раскрытии окна

<img width="1195" height="522" alt="2025-09-08_11-24-12" src="https://github.com/user-attachments/assets/0127ebfa-b33f-44b0-a65b-e8b4d36ca46a" />
