### PR TITLE
feat: Убран текстовый курсор в блоке "Иерархия документов" FRO-721

### DIFF
--- a/src/components/dialogs/AIDocDialogs/HierarchyDocDialog.vue
+++ b/src/components/dialogs/AIDocDialogs/HierarchyDocDialog.vue
@@ -424,6 +424,7 @@ onMounted(async () => {
     max-width: 250px;
     color: $text-color;
     background-color: transparent !important;
+    cursor: default;
   }
   .tree-drop-dragged-item {
     position: fixed;


### PR DESCRIPTION
Изменения с курсором были применены для стандартного списка документов слева.
При открытии раздела с изменением иерархии курсор оставался тем же, исправил.
Теперь в списках документов будет стандартный курсор, указатель появляется только при наведении на стрелку, которая скрывает дочерние документы.