### PR TITLE
fix: Добавлено поле уведомления "появилась новая задача", правки в типах BUGS-1034

### DIFF
--- a/src/components/dialogs/ProjectNotificationsSettings/AdminSettingsList.vue
+++ b/src/components/dialogs/ProjectNotificationsSettings/AdminSettingsList.vue
@@ -41,7 +41,7 @@ const emits = defineEmits<{ update: [{ field: string; value: boolean }] }>();
 
 const settingsList = [
   { title: 'Изменилось название', field: 'disable_project_name' },
-  { title: 'Изменилась иконка', field: 'disable_project_issue' },
+  { title: 'Изменилась иконка', field: 'disable_project_logo' },
   { title: 'Изменился идентификатор', field: 'disable_project_identifier' },
   { title: 'Изменилась приватность', field: 'disable_project_public' },
   { title: 'Изменился лидер проекта', field: 'disable_project_owner' },

--- a/src/components/dialogs/ProjectNotificationsSettings/SettingList.vue
+++ b/src/components/dialogs/ProjectNotificationsSettings/SettingList.vue
@@ -138,6 +138,23 @@
         ></q-checkbox>
       </div>
       <div class="notification-setting">
+        <span>Появилась новая задача</span>
+        <q-checkbox
+          class="justify-center"
+          v-model="authorSetting.disable_issue_new"
+          @update:model-value="
+            emits('updateEmail', invertedSettings(authorSetting))
+          "
+        ></q-checkbox>
+        <q-checkbox
+          class="justify-center"
+          v-model="memberSettings.disable_issue_new"
+          @update:model-value="
+            emits('updateTelegram', invertedSettings(memberSettings))
+          "
+        ></q-checkbox>
+      </div>
+      <div class="notification-setting">
         <span>Изменилась родительская задача</span>
         <q-checkbox
           class="justify-center"

--- a/src/constants/projectNotificationSettings.ts
+++ b/src/constants/projectNotificationSettings.ts
@@ -20,5 +20,6 @@ export const INITIAL_PROJECT_NOTIFICATION_SETTINGS: IProjectNotificationSettings
     disable_issue_transfer: false,
     disable_linked: false,
     disable_sub_issue: false,
+    disable_issue_new: false,
     notify_before_deadline: null,
   };

--- a/src/interfaces/projectNotificationSettings.ts
+++ b/src/interfaces/projectNotificationSettings.ts
@@ -17,5 +17,6 @@ export interface IProjectNotificationSettings {
   disable_issue_transfer: boolean;
   disable_linked: boolean;
   disable_sub_issue: boolean;
+  disable_issue_new: false;
   notify_before_deadline: null | Date;
 }


### PR DESCRIPTION
- Добавлено поле уведомления о появлении новой задачи
- Обновлены типы с учетом нового поля
- Исправлено поле админских настроек, которое пересекается с уведомлениями пользователя

disable_project_issue скорее всего будет удален, так как новое поле делает то же самое, но более подходящее.
для иконки с бэка будет приходить disable_project_logo