### PR TITLE
fix: исправлена задержка перехода в настройки пространств и проектов BUGS-1050

### DIFF
--- a/src/components/MenuLink.vue
+++ b/src/components/MenuLink.vue
@@ -89,6 +89,7 @@
                   no-caps
                   v-close-popup
                   :style="'font-size: 12px;'"
+                  @click="performance.mark('нажали на настрйоки проекта')"
                   :to="`/${currentWorkspaceSlug}/projects/${
                     identifier || id
                   }/settings`"
@@ -107,8 +108,8 @@
                   :style="'font-size: 12px;'"
                   @click="
                     {
-                      (selectedProject = project),
-                        (isNotificationsSettingsOpen = true);
+                      ((selectedProject = project),
+                        (isNotificationsSettingsOpen = true));
                     }
                   "
                 >
@@ -126,8 +127,8 @@
                   :style="'font-size: 12px;'"
                   @click="
                     {
-                      (selectedProject = project),
-                        (isNotificationsAdminSettingsOpen = true);
+                      ((selectedProject = project),
+                        (isNotificationsAdminSettingsOpen = true));
                     }
                   "
                 >

--- a/src/components/MenuLink.vue
+++ b/src/components/MenuLink.vue
@@ -89,7 +89,6 @@
                   no-caps
                   v-close-popup
                   :style="'font-size: 12px;'"
-                  @click="performance.mark('нажали на настрйоки проекта')"
                   :to="`/${currentWorkspaceSlug}/projects/${
                     identifier || id
                   }/settings`"

--- a/src/components/menu/NavMenuHeader.vue
+++ b/src/components/menu/NavMenuHeader.vue
@@ -162,7 +162,6 @@
       />
     </q-btn>
     <q-btn
-      @click="performance.mark('нажали на кнопку')"
       v-if="hasPermission('ws-settings')"
       class="nav-menu__top-nav-button"
       data-id="workspace-settings-button-top"

--- a/src/components/menu/NavMenuHeader.vue
+++ b/src/components/menu/NavMenuHeader.vue
@@ -162,6 +162,7 @@
       />
     </q-btn>
     <q-btn
+      @click="performance.mark('нажали на кнопку')"
       v-if="hasPermission('ws-settings')"
       class="nav-menu__top-nav-button"
       data-id="workspace-settings-button-top"

--- a/src/modules/workspace-settings/ui/WorkspaceSettings.vue
+++ b/src/modules/workspace-settings/ui/WorkspaceSettings.vue
@@ -9,7 +9,18 @@
       :list-tabs="listTabs"
       @set="(val: number) => (wsSettingsTab = val)"
     />
+
+    <div
+      class="column flex-center"
+      style="width: 100%; height: calc(100vh - 300px)"
+      v-if="isLoadingComponent"
+    >
+      <DefaultLoader class="self-center q-mt-md q-mb-md" />
+    </div>
+
     <component
+      v-else
+      :key="wsSettingsTab"
       :is="activeComponent"
       :currentWsInfo="currentWsInfo || {}"
       :currentWsSlug="currentWsSlug"
@@ -24,13 +35,7 @@ import { storeToRefs } from 'pinia';
 // components
 import SettingsTabs from 'src/shared/components/SettingsTabs.vue';
 import LoadPage from 'src/pages/LoadPage.vue';
-// import {
-//   GeneralWorkspaceSettings,
-//   MembersWorkspaceSettings,
-//   ActivitiesWorkspaceSettings,
-//   ActivitiesMapWorkspaceSettings,
-//   IntegrationWorkspaceSettings,
-// } from 'src/modules/workspace-settings/ui/tabs';
+import DefaultLoader from 'src/components/loaders/DefaultLoader.vue';
 
 import { useLoad } from 'src/composables/useLoad';
 
@@ -56,10 +61,24 @@ const props = defineProps({
 });
 
 const wsSettingsTab = ref(0);
+
+const isLoadingComponent = ref(false);
+
+function logAsyncImport(loader: () => Promise<any>) {
+  return defineAsyncComponent(async () => {
+    isLoadingComponent.value = true;
+
+    const mod = await loader();
+
+    isLoadingComponent.value = false;
+    return mod;
+  });
+}
+
 const componentTabs = [
   {
     name: 0,
-    component: defineAsyncComponent(
+    component: logAsyncImport(
       () =>
         import(
           'src/modules/workspace-settings/ui/tabs/GeneralWorkspaceSettings.vue'
@@ -68,7 +87,7 @@ const componentTabs = [
   },
   {
     name: 1,
-    component: defineAsyncComponent(
+    component: logAsyncImport(
       () =>
         import(
           'src/modules/workspace-settings/ui/tabs/MembersWorkspaceSettings.vue'
@@ -77,7 +96,7 @@ const componentTabs = [
   },
   {
     name: 2,
-    component: defineAsyncComponent(
+    component: logAsyncImport(
       () =>
         import(
           'src/modules/workspace-settings/ui/tabs/ActivitiesWorkspaceSettings.vue'
@@ -86,7 +105,7 @@ const componentTabs = [
   },
   {
     name: 3,
-    component: defineAsyncComponent(
+    component: logAsyncImport(
       () =>
         import(
           'src/modules/workspace-settings/ui/tabs/ActivitiesMapWorkspaceSettings.vue'
@@ -95,7 +114,7 @@ const componentTabs = [
   },
   {
     name: 4,
-    component: defineAsyncComponent(
+    component: logAsyncImport(
       () =>
         import(
           'src/modules/workspace-settings/ui/tabs/IntegrationWorkspaceSettings.vue'
@@ -134,7 +153,7 @@ const activeComponent = computed(
     componentTabs.find((tab) => tab.name === wsSettingsTab.value)?.component,
 );
 
-onMounted(async () => {
+onMounted(() => {
   onLoad(currentWsSlug.value, props.isInAdminPanel);
 });
 </script>

--- a/src/modules/workspace-settings/ui/WorkspaceSettings.vue
+++ b/src/modules/workspace-settings/ui/WorkspaceSettings.vue
@@ -19,18 +19,18 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, onMounted, computed } from 'vue';
+import { ref, onMounted, computed, defineAsyncComponent } from 'vue';
 import { storeToRefs } from 'pinia';
 // components
 import SettingsTabs from 'src/shared/components/SettingsTabs.vue';
 import LoadPage from 'src/pages/LoadPage.vue';
-import {
-  GeneralWorkspaceSettings,
-  MembersWorkspaceSettings,
-  ActivitiesWorkspaceSettings,
-  ActivitiesMapWorkspaceSettings,
-  IntegrationWorkspaceSettings,
-} from 'src/modules/workspace-settings/ui/tabs';
+// import {
+//   GeneralWorkspaceSettings,
+//   MembersWorkspaceSettings,
+//   ActivitiesWorkspaceSettings,
+//   ActivitiesMapWorkspaceSettings,
+//   IntegrationWorkspaceSettings,
+// } from 'src/modules/workspace-settings/ui/tabs';
 
 import { useLoad } from 'src/composables/useLoad';
 
@@ -57,11 +57,51 @@ const props = defineProps({
 
 const wsSettingsTab = ref(0);
 const componentTabs = [
-  { name: 0, component: GeneralWorkspaceSettings },
-  { name: 1, component: MembersWorkspaceSettings },
-  { name: 2, component: ActivitiesWorkspaceSettings },
-  { name: 3, component: ActivitiesMapWorkspaceSettings },
-  { name: 4, component: IntegrationWorkspaceSettings },
+  {
+    name: 0,
+    component: defineAsyncComponent(
+      () =>
+        import(
+          'src/modules/workspace-settings/ui/tabs/GeneralWorkspaceSettings.vue'
+        ),
+    ),
+  },
+  {
+    name: 1,
+    component: defineAsyncComponent(
+      () =>
+        import(
+          'src/modules/workspace-settings/ui/tabs/MembersWorkspaceSettings.vue'
+        ),
+    ),
+  },
+  {
+    name: 2,
+    component: defineAsyncComponent(
+      () =>
+        import(
+          'src/modules/workspace-settings/ui/tabs/ActivitiesWorkspaceSettings.vue'
+        ),
+    ),
+  },
+  {
+    name: 3,
+    component: defineAsyncComponent(
+      () =>
+        import(
+          'src/modules/workspace-settings/ui/tabs/ActivitiesMapWorkspaceSettings.vue'
+        ),
+    ),
+  },
+  {
+    name: 4,
+    component: defineAsyncComponent(
+      () =>
+        import(
+          'src/modules/workspace-settings/ui/tabs/IntegrationWorkspaceSettings.vue'
+        ),
+    ),
+  },
 ];
 const listTabs = [
   {
@@ -95,6 +135,6 @@ const activeComponent = computed(
 );
 
 onMounted(async () => {
-  await onLoad(currentWsSlug.value, props.isInAdminPanel);
+  onLoad(currentWsSlug.value, props.isInAdminPanel);
 });
 </script>

--- a/src/modules/workspace-settings/ui/tabs/GeneralWorkspaceSettings.vue
+++ b/src/modules/workspace-settings/ui/tabs/GeneralWorkspaceSettings.vue
@@ -368,7 +368,7 @@ import { Editor } from '@tiptap/vue-3';
 import { useMeta, useQuasar, Screen } from 'quasar';
 import { storeToRefs } from 'pinia';
 import { useRoute } from 'vue-router';
-import { onMounted, ref, computed, nextTick } from 'vue';
+import { onMounted, ref, computed, nextTick, defineAsyncComponent } from 'vue';
 
 // stores
 import { useUtilsStore } from 'src/stores/utils-store';
@@ -407,7 +407,12 @@ import {
 } from 'src/modules/workspace-settings/ui/dialogs';
 import SelectLeader from 'components/selects/SelectLeader.vue';
 import { TIPTAP_TABS } from 'src/constants/tiptap';
-import EditorTipTapV2 from 'src/components/editorV2/EditorTipTapV2.vue';
+// import EditorTipTapV2 from 'src/components/editorV2/EditorTipTapV2.vue';
+
+const EditorTipTapV2 = defineAsyncComponent(
+  () => import('src/components/editorV2/EditorTipTapV2.vue'),
+);
+
 import { isEditorEmpty } from 'src/components/editorV2/utils/editorUtils';
 import AvatarImage from 'src/components/AvatarImage.vue';
 import EditIcon from 'src/components/icons/EditIcon.vue';
@@ -593,7 +598,6 @@ const handleUpdateWorkspace = async () => {
 //     },
 //   );
 // };
-
 
 const isWorkspaceLogo = computed(() => {
   return (

--- a/src/pages/ProjectSettingsPage.vue
+++ b/src/pages/ProjectSettingsPage.vue
@@ -10,17 +10,27 @@
         :list-tabs="listTabs"
         @set="(val: number) => (projectSettingsTab = val)"
       />
-      <component :is="activeTab" @update="projectInfoRefresh" />
+
+      <div
+        class="column flex-center"
+        style="width: 100%; height: calc(100vh - 300px)"
+        v-if="isLoadingComponent"
+      >
+        <DefaultLoader class="self-center q-mt-md q-mb-md" />
+      </div>
+
+      <component v-else :is="activeTab" @update="projectInfoRefresh" />
     </div>
   </q-page>
 </template>
 
 <script setup lang="ts">
+console.time('project-settings-mount');
 // core
 import { useMeta } from 'quasar';
 import { useRoute } from 'vue-router';
 import { storeToRefs } from 'pinia';
-import { computed, onMounted, ref } from 'vue';
+import { computed, defineAsyncComponent, onMounted, ref } from 'vue';
 
 // stores
 import { useRolesStore } from 'stores/roles-store';
@@ -28,15 +38,8 @@ import { useProjectStore } from 'src/stores/project-store';
 
 // components
 import LoadPage from './LoadPage.vue';
+import DefaultLoader from 'src/components/loaders/DefaultLoader.vue';
 import SettingsTabs from 'src/shared/components/SettingsTabs.vue';
-import GeneralProjectSettings from 'src/modules/project-settings/general/ui/GeneralProjectSettings.vue';
-import LabelsProjectSettings from 'src/modules/project-settings/labels/ui/LabelsProjectSettings.vue';
-import ControlProjectSettings from 'src/modules/project-settings/control/ui/ControlProjectSettings.vue';
-import MembersProjectSettings from 'src/modules/project-settings/members/ui/MembersProjectSettings.vue';
-import StatesProjectSettings from 'src/modules/project-settings/states/ui/StatesProjectSettings.vue';
-import RulesProjectSettings from 'src/modules/project-settings/rules/ui/RulesProjectSettings.vue';
-import ActivitiesProjectSettings from 'src/modules/project-settings/activities/ui/ActivitiesProjectSettings.vue';
-import NewIssueTemplate from 'src/modules/project-settings/new-issue-template/ui/NewIssueTemplate.vue';
 
 // stores
 const projectStore = useProjectStore();
@@ -53,24 +56,77 @@ const route = useRoute();
 
 const metadata = ref({ title: 'Загрузка...' });
 
+const isLoadingComponent = ref(false);
+
+function logAsyncImport(loader: () => Promise<any>) {
+  return defineAsyncComponent(async () => {
+    isLoadingComponent.value = true;
+
+    const mod = await loader();
+
+    isLoadingComponent.value = false;
+    return mod;
+  });
+}
+
 const activeTab = computed(() => {
   switch (projectSettingsTab.value) {
     case 1:
-      return ControlProjectSettings;
+      return logAsyncImport(
+        () =>
+          import(
+            'src/modules/project-settings/control/ui/ControlProjectSettings.vue'
+          ),
+      );
     case 2:
-      return MembersProjectSettings;
+      return logAsyncImport(
+        () =>
+          import(
+            'src/modules/project-settings/members/ui/MembersProjectSettings.vue'
+          ),
+      );
     case 3:
-      return StatesProjectSettings;
+      return logAsyncImport(
+        () =>
+          import(
+            'src/modules/project-settings/states/ui/StatesProjectSettings.vue'
+          ),
+      );
     case 4:
-      return LabelsProjectSettings;
+      return logAsyncImport(
+        () =>
+          import(
+            'src/modules/project-settings/labels/ui/LabelsProjectSettings.vue'
+          ),
+      );
     case 5:
-      return RulesProjectSettings;
+      return logAsyncImport(
+        () =>
+          import(
+            'src/modules/project-settings/rules/ui/RulesProjectSettings.vue'
+          ),
+      );
     case 6:
-      return ActivitiesProjectSettings;
+      return logAsyncImport(
+        () =>
+          import(
+            'src/modules/project-settings/activities/ui/ActivitiesProjectSettings.vue'
+          ),
+      );
     case 7:
-      return NewIssueTemplate;
+      return logAsyncImport(
+        () =>
+          import(
+            'src/modules/project-settings/new-issue-template/ui/NewIssueTemplate.vue'
+          ),
+      );
     default:
-      return GeneralProjectSettings;
+      return logAsyncImport(
+        () =>
+          import(
+            'src/modules/project-settings/general/ui/GeneralProjectSettings.vue'
+          ),
+      );
   }
 });
 
@@ -133,8 +189,8 @@ const projectInfoRefresh = async () => {
     });
 };
 
-onMounted(async () => {
-  performance.mark('маунт прожект сеттингс');
-  await projectInfoRefresh();
+onMounted(() => {
+  console.timeEnd('project-settings-mount');
+  projectInfoRefresh();
 });
 </script>

--- a/src/pages/ProjectSettingsPage.vue
+++ b/src/pages/ProjectSettingsPage.vue
@@ -133,5 +133,8 @@ const projectInfoRefresh = async () => {
     });
 };
 
-onMounted(async () => await projectInfoRefresh());
+onMounted(async () => {
+  performance.mark('маунт прожект сеттингс');
+  await projectInfoRefresh();
+});
 </script>

--- a/src/pages/WorkspaceSettingsPage.vue
+++ b/src/pages/WorkspaceSettingsPage.vue
@@ -5,6 +5,7 @@
 </template>
 
 <script setup lang="ts">
+console.time('settings-mount');
 // utils
 import { useMeta } from 'quasar';
 import { storeToRefs } from 'pinia';
@@ -40,6 +41,7 @@ function setAnotherTitle(title: string) {
 }
 
 onMounted(async () => {
+  console.timeEnd('settings-mount');
   await workspaceStore.getWorkspaceInfo(route.params.workspace as string);
 
   if (hasPermissionByWorkspace(workspaceInfo?.value, 'ws-settings') === false) {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -21,8 +21,8 @@ export default route(function (/* { store, ssrContext } */) {
   const createHistory = process.env.SERVER
     ? createMemoryHistory
     : process.env.VUE_ROUTER_MODE === 'history'
-    ? createWebHistory
-    : createWebHashHistory;
+      ? createWebHistory
+      : createWebHashHistory;
 
   const Router = createRouter({
     scrollBehavior: () => ({ left: 0, top: 0 }),
@@ -32,6 +32,15 @@ export default route(function (/* { store, ssrContext } */) {
     // quasar.conf.js -> build -> vueRouterMode
     // quasar.conf.js -> build -> publicPath
     history: createHistory(process.env.VUE_ROUTER_BASE),
+  });
+
+  Router.beforeEach((to, from, next) => {
+    console.time(`router-guard-${to.fullPath}`);
+    next();
+  });
+
+  Router.afterEach((to) => {
+    console.timeEnd(`router-guard-${to.fullPath}`);
   });
 
   Router.beforeEach((to, from, next) => {


### PR DESCRIPTION
Суть проблемы:
Из-за динамических импортов в роутере, при переходе на страницу подтягивается весь ее бандл. И в те моменты, когда файлов не оказалось в кеше, они тянутся с сервера. Если страница жирная, то выходит очень много чанков, из-за чего роутинг блокируется пока не получит всю страницу. На локалке это заметно сильнее. Это можно увидеть через перфоманс и нетворк в девтулах.

По замерам для перехода на страницу настроек пространства получилось следующее (при очищенном кеше):
Время от нажатия на кнопку до полного перехода на страницу: 25 секунд
Время монтирования компонента страницы: 13 секунд.

Решение:
При переходе в настройки пользователь попадает на первый таб, нет смысла грузить сразу все табы, поэтому импорт компонентов сделал асинхронными.

Время монтирования сразу сократилось:
Время от нажатия на кнопку до полного перехода на страницу: 10 секунд 
Время монтирования компонента страницы: 100 ms

Остальное время занимает подготовка первого таба, самое большое там - тип тап, его импорт тоже сделал асинхронным. Хуке маунта убрал await. И добавил дополнительный лоадер, чтобы роутер вообще не ждал первый таб и сразу перешел на страницу.

Итоговые замеры:
Время от нажатия на кнопку до полного перехода на страницу: 800 ms
Время монтирования компонента страницы: 300 ms

В настройках проекта сделал аналогично.
