### PR TITLE
fix: добавлен пропуск для коротких ссылок на фильтры FRO-724

### DIFF
--- a/quasar.config.js
+++ b/quasar.config.js
@@ -201,6 +201,7 @@ module.exports = configure(function (ctx) {
         cfg.navigateFallbackDenylist = cfg.navigateFallbackDenylist || [];
         cfg.navigateFallbackDenylist.push(/^\/api\/.*$/);
         cfg.navigateFallbackDenylist.push(/^\/i\/.*$/);
+        cfg.navigateFallbackDenylist.push(/^\/sf\/.*$/);
         cfg.navigateFallbackDenylist.push(/^\/d\/.*$/);
         cfg.navigateFallbackDenylist.push(/^\/uploads\/.*$/);
       },


### PR DESCRIPTION
В настройках квазара добавил путь для коротких ссылок на фильтры для прода