### PR TITLE
fix: оптимизирован переход на страницу профиля BUGS-1057

### DIFF
--- a/src/modules/profile-settings/ProfileSettings.vue
+++ b/src/modules/profile-settings/ProfileSettings.vue
@@ -8,25 +8,30 @@
       @set="(val: number) => setTab(val)"
     />
 
-    <GeneralProfileSettings v-if="profileSettingsTab === 0" />
-    <ActivitiesProfileSettings v-else-if="profileSettingsTab === 1" />
-    <DesignProfileSettings v-else-if="profileSettingsTab === 2" />
+    <div
+      class="column flex-center"
+      style="width: 100%; height: calc(100vh - 300px)"
+      v-if="isLoadingComponent"
+    >
+      <DefaultLoader class="self-center q-mt-md q-mb-md" />
+    </div>
+
+    <component v-else :is="listTabs[profileSettingsTab].component" />
   </q-page>
 </template>
 
 <script setup lang="ts">
 // components
 import SettingsTabs from 'src/shared/components/SettingsTabs.vue';
-import GeneralProfileSettings from './components/GeneralProfileSettings.vue';
-import ActivitiesProfileSettings from './components/ActivitiesProfileSettings.vue';
-import DesignProfileSettings from './components/DesignProfileSettings.vue';
 import ProfilePreview from './components/ProfilePreview.vue';
+import DefaultLoader from 'src/components/loaders/DefaultLoader.vue';
 // composables
 import { useProfileTabs } from './composables/useProfileTabs';
 import { useMetadataTitle } from './composables/useMetadataTitle';
 import { useUserLoadInfo } from './composables/useUserLoadInfo';
 
-const { listTabs, profileSettingsTab, setTab } = useProfileTabs();
+const { listTabs, profileSettingsTab, setTab, isLoadingComponent } =
+  useProfileTabs();
 useUserLoadInfo();
 useMetadataTitle();
 </script>

--- a/src/modules/profile-settings/composables/useProfileTabs.ts
+++ b/src/modules/profile-settings/composables/useProfileTabs.ts
@@ -1,20 +1,41 @@
-import { ref } from 'vue';
+import { ref, defineAsyncComponent } from 'vue';
 import { ISettingsTab } from 'src/shared/types/settings-tabs';
 
 export const useProfileTabs = () => {
+  const isLoadingComponent = ref(false);
+
+  function asyncImport(loader: () => Promise<any>) {
+    return defineAsyncComponent(async () => {
+      isLoadingComponent.value = true;
+
+      const component = await loader();
+
+      isLoadingComponent.value = false;
+      return component;
+    });
+  }
   // Вкладки настроек профиля
   const listTabs = [
     {
       name: 0,
       label: 'Основные',
+      component: asyncImport(
+        () => import('../components/GeneralProfileSettings.vue'),
+      ),
     },
     {
       name: 1,
       label: 'Активности',
+      component: asyncImport(
+        () => import('../components/ActivitiesProfileSettings.vue'),
+      ),
     },
     {
       name: 2,
       label: 'Оформление',
+      component: asyncImport(
+        () => import('../components/DesignProfileSettings.vue'),
+      ),
     },
   ] as ISettingsTab[];
 
@@ -22,5 +43,5 @@ export const useProfileTabs = () => {
   const setTab = (value: number): void => {
     profileSettingsTab.value = value;
   };
-  return { listTabs, profileSettingsTab, setTab };
+  return { listTabs, profileSettingsTab, setTab, isLoadingComponent };
 };

--- a/src/shared/types/settings-tabs.d.ts
+++ b/src/shared/types/settings-tabs.d.ts
@@ -1,6 +1,9 @@
+import { Component } from 'vue';
+
 export interface ISettingsTab {
   name: number;
   label: string;
   dataId?: string;
   isDisabled?: boolean;
+  component?: Component;
 }


### PR DESCRIPTION
Сделано аналогично переходу в настройки проекта и пространства через асинхронные компоненты
Замеры:
До оптимизации переход без кеша: 7 секунд
После: 500 мс