### PR TITLE
fix: Исправлен баг, при котором изменение задачи обрабатывалось как изменение даты BUGS-1067

### DIFF
--- a/src/components/activity/renders/issue-activity.ts
+++ b/src/components/activity/renders/issue-activity.ts
@@ -136,9 +136,9 @@ export function issueActivityRender(activity: DtoEntityActivityFull, onlyWorkspa
                 <span/>`;
 
     case 'description':
-      return `<span>обновил(-а) описание в задаче ${link} ${workspaceSource}<span/>`;
+      return `<span>изменил(-а) описание в задаче ${link} ${workspaceSource}<span/>`;
     case 'name':
-      return `<span>обновил(-а) название в задаче ${link} ${workspaceSource}<span/>`;
+      return `<span>изменил(-а) название в задаче ${link} ${workspaceSource}<span/>`;
     case 'attachment':
       action = translateVerb(activity.verb as string);
       return `<span>${action} вложение "${

--- a/src/utils/canBeConvertedToDate.ts
+++ b/src/utils/canBeConvertedToDate.ts
@@ -1,0 +1,5 @@
+// Проверка на возможную дату в строке
+export function canBeConvertedToDate(str: string): boolean {
+  const date = new Date(str);
+  return !isNaN(date.getTime());
+}

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -1,6 +1,7 @@
 import aiplan from 'src/utils/aiplan';
 import { IProject } from 'src/interfaces/projects';
 import { formatDate } from './time';
+import { canBeConvertedToDate } from './canBeConvertedToDate';
 
 export const addSpaceIfCamelCase = (str: string) =>
   str.replace(/([a-z])([A-Z])/g, '$1 $2');
@@ -329,16 +330,24 @@ export const getHistoryText = (m: any, wsProjects: IProject[]) => {
 
     case 'target_date':
       if (m.verb === 'updated') {
-        const newDate = formatDate(m.new_value ?? '');
-        const oldDate = formatDate(
-          m.old_value ? m.old_value.replace(/"/g, '') : '',
-        );
+        const newDate =
+          m.new_value instanceof Date || canBeConvertedToDate(m.new_value)
+            ? formatDate(m.new_value)
+            : '';
+        const oldDate =
+          m.old_value &&
+          (m.old_value instanceof Date || canBeConvertedToDate(m.old_value))
+            ? formatDate(m.old_value.replace(/"/g, ''))
+            : '';
+
         if (m.old_value === '<nil>' || !m.old_value) {
           return `установил(-а) срок исполнения ${newDate}`;
         } else if (m.new_value === '' && oldDate) {
           return `убрал(-а) срок исполнения ${oldDate}`;
         } else {
-          return `изменил(-а) срок исполнения с ${oldDate} на ${newDate}`;
+          return oldDate && newDate
+            ? `изменил(-а) срок исполнения с ${oldDate} на ${newDate}`
+            : 'изменил(-а) срок исполнения';
         }
       }
 

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -313,6 +313,9 @@ export const getHistoryText = (m: any, wsProjects: IProject[]) => {
       }
 
     case 'description':
+      if (m.verb === 'updated') {
+        return 'изменил(-а) описание'
+      }
       if (m.entity_type === 'doc') {
         return 'изменил(-а) описание';
       }


### PR DESCRIPTION
Добавлена обработка активности при изменении описания.
Согласован и изменен текст активностей для однообразия.
Добавлена и оставлена проверка на наличие даты во избежания отображения InvalidDate