### PR TITLE
fix: Исправлен баг с плавающими кнопками BUGS-1070

### DIFF
--- a/src/pages/AiDocPage.vue
+++ b/src/pages/AiDocPage.vue
@@ -443,10 +443,8 @@ watch(
   justify-content: flex-end;
   gap: 1rem;
   width: 99%;
-  height: auto;
-  position: sticky;
-  bottom: 30px;
 }
+
 .issue-panel__wrapper {
   gap: 8px;
   @media screen and (max-width: 550px) {


### PR DESCRIPTION
Удалены лишние стили у блока кнопок на странице документа. 
На мобильных версиях также все корректно отображается.
В остальных редакторах проблемы не обнаружил.