### PR TITLE
fix: исправлена не работающая кнопка регистрации BUGS-1074

### DIFF
--- a/src/components/RegisterPanel.vue
+++ b/src/components/RegisterPanel.vue
@@ -21,7 +21,9 @@
       type="submit"
       no-caps
       :disable="
-        email.length === 0 || captchaPayload === '' || isEmail(email) !== true
+        email.length === 0 ||
+        (isEnabledCaptcha && captchaPayload === '') ||
+        isEmail(email) !== true
       "
       :loading="loading"
     >


### PR DESCRIPTION
Условие блокировки кнопки не учитывало флаг isEnabledCaptcha, из-за чего при отключенной капче (как сейчас на тесте) captchaPayload ничего не содержал, из-за чего условие было тру и кнопка блокировалась

<img width="489" height="330" alt="image" src="https://github.com/user-attachments/assets/527ac7dd-91dd-48bd-bc9a-105b2d9be151" />
