### PR TITLE
fix: изменение полей задачи больше не приводит к обновлению редактора BUGS-none

### DIFF
--- a/src/components/SelectBlockIssues.vue
+++ b/src/components/SelectBlockIssues.vue
@@ -70,7 +70,7 @@ const props = withDefaults(
     target: '_self',
   },
 );
-const emits = defineEmits<{ refresh: [] }>();
+const emits = defineEmits<{ refresh: [data: any] }>();
 
 const api = useAiplanStore();
 
@@ -97,7 +97,7 @@ const saveBlockIssues = async (items) => {
     .issuePartialUpdate(props.workspaceId, props.projectid, props.issueid, data)
     .then(() => {
       setNotificationView({ type: 'success', open: true });
-      emits('refresh');
+      emits('refresh', items);
     });
 };
 
@@ -116,7 +116,7 @@ const updateModelValue = (val: any) => {
     .issuePartialUpdate(props.workspaceId, props.projectid, props.issueid, data)
     .then(() => {
       setNotificationView({ type: 'success', open: true });
-      emits('refresh');
+      emits('refresh', ids);
       delete listDisableIssue.value[val[nameDetail.value].id];
     })
     .catch(() => {
@@ -125,8 +125,9 @@ const updateModelValue = (val: any) => {
 };
 
 const getLabel = (val: any) => {
-  return `${issueData.value.project_detail.identifier}-${val[nameDetail.value]
-    ?.sequence_id}`;
+  return `${issueData.value.project_detail.identifier}-${
+    val[nameDetail.value]?.sequence_id
+  }`;
 };
 
 const disableIssueItem = (val: any) => {

--- a/src/components/SelectDate.vue
+++ b/src/components/SelectDate.vue
@@ -170,7 +170,7 @@ export default defineComponent({
             )
             .then(() => {
               setNotificationView({ type: 'success', open: true });
-              emit('refresh');
+              emit('refresh', proxyDate.value);
             });
         } else {
           emit('update:date', proxyDate.value);

--- a/src/components/SelectParentIssue.vue
+++ b/src/components/SelectParentIssue.vue
@@ -59,7 +59,7 @@ const props = defineProps<{
 }>();
 
 const emits = defineEmits<{
-  refresh: [];
+  refresh: [issue: any | null];
   'update:issue': [issue: any | null];
 }>();
 
@@ -91,7 +91,7 @@ const saveParentIssue = (issue: any, extendedIssue?: any) => {
       )
       .then(() => {
         setNotificationView({ type: 'success', open: true });
-        emits('refresh');
+        emits('refresh', issue);
         onLoad();
       });
   else emits('update:issue', issue && props.newIssue ? extendedIssue : null);

--- a/src/components/issue-panels/SingleIssueDrawer.vue
+++ b/src/components/issue-panels/SingleIssueDrawer.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="col q-pb-sm q-px-sm">
-    <SingleIssueButtons @refresh="refresh()" />
+    <SingleIssueButtons />
 
     <q-separator class="issue-panel__separator" />
 
@@ -24,7 +24,6 @@
           "
           :states-from-cache="statesCache[issueData?.project]"
           @set-status="(val) => (issueData.state_detail = val)"
-          @refresh="refresh()"
         />
       </div>
     </div>
@@ -86,7 +85,6 @@
             !hasPermissionByIssue(issueData, project, 'change-issue-basic')
           "
           :current-member="user"
-          @refresh="refresh()"
         ></SelectAssignee>
       </div>
     </div>
@@ -112,7 +110,6 @@
           :isDisabled="
             !hasPermissionByIssue(issueData, project, 'change-issue-basic')
           "
-          @refresh="refresh()"
         ></SelectWatchers>
       </div>
     </div>
@@ -137,7 +134,7 @@
           :is-disabled="
             !hasPermissionByIssue(issueData, project, 'change-issue-primary')
           "
-          @refresh="refresh()"
+          @update:priority="(val) => (issueData.priority = val)"
         >
         </SelectPriority>
       </div>
@@ -175,7 +172,7 @@
           :is-disabled="
             !hasPermissionByIssue(issueData, project, 'change-issue-primary')
           "
-          @refresh="refresh()"
+          @refresh="(val) => (issueData.target_date = val)"
         />
       </div>
     </div>
@@ -229,7 +226,7 @@
           :isDisabled="
             hasPermissionByIssue(issueData, project, 'change-issue-primary')
           "
-          @refresh="refresh()"
+          @refresh="updateParent"
         ></SelectParentIssue>
         <q-btn
           v-if="
@@ -261,7 +258,7 @@
           :isDisabled="
             hasPermissionByIssue(issueData, project, 'change-issue-primary')
           "
-          @refresh="refresh()"
+          @refresh="updateBlockerListAndLinks"
         />
       </div>
     </div>
@@ -283,7 +280,7 @@
           :isDisabled="
             hasPermissionByIssue(issueData, project, 'change-issue-primary')
           "
-          @refresh="refresh()"
+          @refresh="updateBlockerListAndLinks"
         />
       </div>
     </div>
@@ -297,7 +294,7 @@
       :isDisabled="
         hasPermissionByIssue(issueData, project, 'change-issue-secondary')
       "
-      @refresh="refresh()"
+      @refresh="updateBlockerListAndLinks"
     >
     </SelectLinks>
   </div>
@@ -376,6 +373,32 @@ const refresh = async () => {
   );
 };
 
+const updateParent = async (issueId: string) => {
+  await singleIssueStore
+    .getIssueDataById(
+      currentWorkspaceSlug.value,
+      currentProjectID.value,
+      issueId,
+    )
+    .then((res) => {
+      issueData.value.parent_detail = res.data;
+    });
+};
+
+const updateBlockerListAndLinks = async () => {
+  await singleIssueStore
+    .getIssueDataById(
+      currentWorkspaceSlug.value,
+      currentProjectID.value,
+      issueData.value.id,
+    )
+    .then((res) => {
+      issueData.value.blocker_issues = res.data.blocker_issues;
+      issueData.value.blocked_issues = res.data.blocked_issues;
+      issueData.value.issue_link = res.data.issue_link;
+    });
+};
+
 const handleRemoveParentIssue = async () => {
   await singleIssueStore
     .updateIssueData(
@@ -390,7 +413,7 @@ const handleRemoveParentIssue = async () => {
         open: true,
         customMessage: SUCCESS_UPDATE_DATA,
       });
-      await refresh();
+      issueData.value.parent_detail = null;
     });
 };
 

--- a/src/components/issue-panels/SingleIssueDrawer.vue
+++ b/src/components/issue-panels/SingleIssueDrawer.vue
@@ -366,12 +366,6 @@ const { currentIssueID, issueData } = storeToRefs(singleIssueStore);
 const { currentWorkspaceSlug } = storeToRefs(workspaceStore);
 
 // functions
-const refresh = async () => {
-  await singleIssueStore.getIssueData(
-    currentWorkspaceSlug.value,
-    currentProjectID.value,
-  );
-};
 
 const updateParent = async (issueId: string) => {
   await singleIssueStore


### PR DESCRIPTION
Основная проблема: каждое обновление полей из правой колонки вызывает refresh, который в стор подтягивает свежие данные о задаче, это приводит к обновлению описания и тайтла, которые возможно в этот момент уже были отредактированы

Возможно было бы проще изменить функцию refresh, чтобы она обновляла только поля из правой колонки
Но мой вариант убирает лишние запросы где это возможно