### PR TITLE
feat: Ограничение на размер числа для telegram_id FRO-735

### DIFF
--- a/src/pages/OnBoardingPage.vue
+++ b/src/pages/OnBoardingPage.vue
@@ -56,6 +56,10 @@
             !val ||
             !isNaN(Number(val)) ||
             'Telegram ID может содержать только цифры',
+          (val) =>
+            !val ||
+            val.length <= 15 ||
+            'Telegram ID слишком длинный (макс. 15 цифр)',
         ]"
         class="base-input onboarding-input onboarding-input_optional"
         data-id="telegram-id-settings"
@@ -187,8 +191,8 @@ export default defineComponent({
       username.value.validate();
 
       me.value.telegram_id
-        ? me.value.telegram_id = Number(me.value.telegram_id)
-        : me.value.telegram_id = null;
+        ? (me.value.telegram_id = Number(me.value.telegram_id))
+        : (me.value.telegram_id = null);
 
       if (
         firstName.value.hasError &&
@@ -221,8 +225,8 @@ export default defineComponent({
 
     onMounted(async () => {
       await userStore.getUserInfo().then((data) => {
-          return data;
-        });
+        return data;
+      });
       await utilsStore.getNotificationBotUrl();
     });
 


### PR DESCRIPTION
Превышался лимит на размер числа, из-за чего терялась точность при преобразовании из строки.
Добавлено ограничение на 15 цифр, достичь лимита теперь нельзя