### PR TITLE
fix: изменение полей задачи больше не приводит к обновлению редактора BUGS-1075

### DIFF
--- a/src/components/SelectBlockIssues.vue
+++ b/src/components/SelectBlockIssues.vue
@@ -70,7 +70,7 @@ const props = withDefaults(
     target: '_self',
   },
 );
-const emits = defineEmits<{ refresh: [] }>();
+const emits = defineEmits<{ refresh: [data: any] }>();
 
 const api = useAiplanStore();
 
@@ -97,7 +97,7 @@ const saveBlockIssues = async (items) => {
     .issuePartialUpdate(props.workspaceId, props.projectid, props.issueid, data)
     .then(() => {
       setNotificationView({ type: 'success', open: true });
-      emits('refresh');
+      emits('refresh', items);
     });
 };
 
@@ -116,7 +116,7 @@ const updateModelValue = (val: any) => {
     .issuePartialUpdate(props.workspaceId, props.projectid, props.issueid, data)
     .then(() => {
       setNotificationView({ type: 'success', open: true });
-      emits('refresh');
+      emits('refresh', ids);
       delete listDisableIssue.value[val[nameDetail.value].id];
     })
     .catch(() => {
@@ -125,8 +125,9 @@ const updateModelValue = (val: any) => {
 };
 
 const getLabel = (val: any) => {
-  return `${issueData.value.project_detail.identifier}-${val[nameDetail.value]
-    ?.sequence_id}`;
+  return `${issueData.value.project_detail.identifier}-${
+    val[nameDetail.value]?.sequence_id
+  }`;
 };
 
 const disableIssueItem = (val: any) => {

--- a/src/components/SelectDate.vue
+++ b/src/components/SelectDate.vue
@@ -170,7 +170,7 @@ export default defineComponent({
             )
             .then(() => {
               setNotificationView({ type: 'success', open: true });
-              emit('refresh');
+              emit('refresh', proxyDate.value);
             });
         } else {
           emit('update:date', proxyDate.value);

--- a/src/components/SelectParentIssue.vue
+++ b/src/components/SelectParentIssue.vue
@@ -59,7 +59,7 @@ const props = defineProps<{
 }>();
 
 const emits = defineEmits<{
-  refresh: [];
+  refresh: [issue: any | null];
   'update:issue': [issue: any | null];
 }>();
 
@@ -91,7 +91,7 @@ const saveParentIssue = (issue: any, extendedIssue?: any) => {
       )
       .then(() => {
         setNotificationView({ type: 'success', open: true });
-        emits('refresh');
+        emits('refresh', issue);
         onLoad();
       });
   else emits('update:issue', issue && props.newIssue ? extendedIssue : null);

--- a/src/components/issue-panels/SingleIssueButtons.vue
+++ b/src/components/issue-panels/SingleIssueButtons.vue
@@ -116,6 +116,7 @@ const switchDraft = async () => {
       { draft: !issueData.value.draft },
     )
     .then(() => {
+      issueData.value.draft = !issueData.value.draft;
       setNotificationView({
         type: 'success',
         open: true,


### PR DESCRIPTION
Основная проблема: каждое обновление полей из правой колонки вызывает refresh, который в стор подтягивает свежие данные о задаче, это приводит к обновлению описания и тайтла, которые возможно в этот момент уже были отредактированы

Возможно было бы проще изменить функцию refresh, чтобы она обновляла только поля из правой колонки
Но мой вариант убирает лишние запросы где это возможно