### PR TITLE
fix: колонка с названием вставляется в начало при сбросе фильтров BUGS-1129

### DIFF
--- a/src/modules/issue-list/constants/defaultProps.ts
+++ b/src/modules/issue-list/constants/defaultProps.ts
@@ -17,6 +17,7 @@ export const DEFAULT_VIEW_PROPS = {
   },
   group_tables_hide: {},
   columns_to_show: [
+    'name',
     'priority',
     'state',
     'target_date',
@@ -29,7 +30,6 @@ export const DEFAULT_VIEW_PROPS = {
     'linked_issues_count',
     'link_count',
     'attachment_count',
-    'name',
   ],
   page_size: 25,
   draft: true,


### PR DESCRIPTION
changed file показывается странно, но я только name передвинул в начало в columns_to_show