### PR TITLE
fix: обновление апи и правка в прогресс баре FRO-648

### DIFF
--- a/src/components/progress-bars/StatusLinearProgressBar.vue
+++ b/src/components/progress-bars/StatusLinearProgressBar.vue
@@ -68,7 +68,7 @@ function calculateSum(keys: string[]) {
 }
 
 const progress_count = computed(() => {
-  if (!props.stats?.completed || !props.stats?.all_issues) return '';
+  if (!props.stats?.all_issues) return '';
   return `(${props.stats?.completed}/${props.stats?.all_issues})`;
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3,9 +3,9 @@
 
 
 "@aisa-it/aiplan-api-ts@^1.90.0":
-  version "1.100.0"
-  resolved "https://registry.yarnpkg.com/@aisa-it/aiplan-api-ts/-/aiplan-api-ts-1.100.0.tgz#82734030d8c8f2270c0a758e914a32e4cef41dc4"
-  integrity sha512-7SRZYWP33xKMX9oNqD6+FSKaaSBrS6mAJGMx4Q5gNe2xzS4qzSEEVsi3BZaRjAkN+jnvHPmvjINVxmn7ov2oig==
+  version "1.104.0"
+  resolved "https://registry.yarnpkg.com/@aisa-it/aiplan-api-ts/-/aiplan-api-ts-1.104.0.tgz#88f9d014f36014b044f7537a21d97e009f433e63"
+  integrity sha512-1Cc8aRDK1i9qg/wxK3Tv2e+Bs/IyKIiEKWVVTWfnyCBEQxqnMgUbfEjOdrydOVi8TRpFUknO6w4iX75hFWZ/6g==
   dependencies:
     axios "^1.7.9"
 


### PR DESCRIPTION
Подпись с количеством выполненых задач в прогресс баре теперь отображается при 0 выполненных задач

<img width="830" height="342" alt="image" src="https://github.com/user-attachments/assets/319c3785-0ba5-4441-9bb2-c94385eab74b" />
