### PR TITLE
fix: исправлены открытые по дефолту элементы главного меню FRO-819

### DIFF
--- a/src/components/ExpansionItem.vue
+++ b/src/components/ExpansionItem.vue
@@ -130,7 +130,7 @@ watch(
   isOpen,
   (open) => {
     if (!isMobile.value) {
-      isExpanded.value = open ?? false;
+      isExpanded.value = open ?? props.isDefaultOpen ?? false;
     }
   },
   { immediate: true },

--- a/src/composables/useExpansionItemResize.ts
+++ b/src/composables/useExpansionItemResize.ts
@@ -75,7 +75,7 @@ export function useExpansionItemResize(
       id,
       el: menuItemRef.value,
       minHeight: minHeight.value,
-      open: isOpen.value ?? false,
+      open: isOpen.value ?? isExpanded.value,
     });
   });
 


### PR DESCRIPTION
Испралены ExpansionItem и useExpansionItemResize.ts, теперь учитываются открытые по дефолту элементы меню