### PR TITLE
fix: Исправлено появление двойного превью BUGS-1189

### DIFF
--- a/src/modules/issue-list/components/PinnedIssueCard.vue
+++ b/src/modules/issue-list/components/PinnedIssueCard.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     class="pinned-card elevator-1"
-    @click="emits('openPreview', card.sequence_id)"
+    @click="emits('openIssuePreview', card)"
   >
     <div class="pinned-card__header">
       <span class="pinned-card__issue-id">
@@ -90,17 +90,18 @@ import aiplan from 'src/utils/aiplan';
 import QuantityChip from 'src/components/QuantityChip.vue';
 import IssueContextMenu from 'src/shared/components/IssueContextMenu.vue';
 import { useUserActivityNavigation } from 'src/composables/useUserActivityNavigation';
+import { DtoIssue } from '@aisa-it/aiplan-api-ts/src/data-contracts';
 
 const { user } = storeToRefs(useUserStore());
 
-const props = defineProps<{ card: any }>();
+const props = defineProps<{ card: DtoIssue }>();
 const avatarText = aiplan.UserName;
 
 const isParent = computed((): boolean => {
   return !!props.card?.parent && !!props.card?.parent_detail?.sequence_id;
 });
 
-const emits = defineEmits(['refresh', 'updateTable', 'openPreview']);
+const emits = defineEmits(['refresh', 'updateTable', 'openIssuePreview']);
 
 const { navigateToActivityPage } = useUserActivityNavigation();
 </script>

--- a/src/modules/issue-list/components/gantt-view/GanttView.vue
+++ b/src/modules/issue-list/components/gantt-view/GanttView.vue
@@ -17,6 +17,7 @@
             @open-issue-preview="handleOpenPreview"
             @refresh-issue="refresh"
             style="width: 100%"
+            ref="activeListRef"
             :class="{
               'sprint-margin-default': contextType === 'sprint',
               'project-margin-default': contextType === 'project',
@@ -27,6 +28,7 @@
             :context-type="contextType"
             @open-issue-preview="handleOpenPreview"
             style="height: 100%"
+            ref="activeListRef" 
             :class="{
               'sprint-margin-grouped': contextType === 'sprint',
               'project-margin-grouped': contextType === 'project',
@@ -62,7 +64,7 @@ const props = defineProps<{
 }>();
 
 const emits = defineEmits<{
-  openIssuePreview: [issue: DtoIssue, pagination: QuasarPagination, entity: any];
+  openIssuePreview: [issue: DtoIssue, pagination: QuasarPagination | undefined, entity: any];
   refreshIssue: [issues: DtoIssue[]];
 }>();
 
@@ -92,6 +94,25 @@ let oldSplitter = 50;
 const handleOpenPreview = (issue: DtoIssue, pagination?: QuasarPagination, entity?: any) => {
   emits('openIssuePreview', issue, pagination, entity);
 };
+
+const activeListRef = ref<InstanceType<typeof DefaultIssueList> | InstanceType<typeof GroupedIssueList> | null>(null);
+
+function setRefreshContext(issue: DtoIssue, pagination?: QuasarPagination, entity?: any) {
+  if (activeListRef.value && typeof (activeListRef.value as any).setRefreshContext === 'function') {
+    (activeListRef.value as any).setRefreshContext(issue, pagination, entity);
+  }
+}
+
+function refreshByPreview(isFullUpdate: boolean = false) {
+  if (activeListRef.value && typeof (activeListRef.value as any).refreshByPreview === 'function') {
+    (activeListRef.value as any).refreshByPreview(isFullUpdate);
+  }
+}
+
+defineExpose({
+  setRefreshContext,
+  refreshByPreview,
+});
 
 watch(
   () => isPreview.value,
@@ -129,6 +150,7 @@ watch(
   { immediate: true },
 );
 </script>
+
 <style lang="scss" scoped>
 .sprint-margin-default {
   margin-top: 91px;


### PR DESCRIPTION
Баг возникал из-за разных экземпляров компонента, которые подвязывались на один store.

Сделал превью задачи IssuePreview единственным компонентом, поднял выше по иерархии и связал в нужных точках.
Теперь при появлении нового представления будет достаточно делать эмит с данными о задаче, пагинации и сущности, оставляя только функцию для обновления.