### PR TITLE
fix: Закрытие предпросмотра задачи при упоминании BUGS-1198

### DIFF
--- a/src/directives/click-outside.ts
+++ b/src/directives/click-outside.ts
@@ -14,6 +14,10 @@ export default {
         return;
       }
 
+      if (!document.documentElement.contains(target)) {
+        return;
+      }
+
       if (!(el === target || el.contains(target))) {
         const isClickInsideExcludedElement =
           target.closest(classPrevent) ||


### PR DESCRIPTION
Исправлена директива click-outside
Теперь, если элемент, по которому кликнули, уже был удален из документа, директива просто проигнорирует этот клик и предпросмотр не закроется