### PR TITLE
fix: получение актуальных проектов после удаления, убраны лишние запросы BUGS-1208

### DIFF
--- a/src/modules/project-settings/general/services/api.ts
+++ b/src/modules/project-settings/general/services/api.ts
@@ -4,7 +4,9 @@ const deleteProject = async (
   workspaceSlug: string,
   projectId: string,
 ): Promise<void> => {
-  projectsApi.deleteProject(workspaceSlug, projectId).then((res) => res.data);
+  return projectsApi
+    .deleteProject(workspaceSlug, projectId)
+    .then((res) => res.data);
 };
 
 export { deleteProject };

--- a/src/modules/project-settings/general/ui/GeneralProjectSettings.vue
+++ b/src/modules/project-settings/general/ui/GeneralProjectSettings.vue
@@ -267,7 +267,6 @@ const updateStores = async () => {
       project.value.id,
     ),
     workspaceStore.getWorkspaceProjects(currentWorkspaceSlug.value as string),
-    userStore.getFavouriteProjects(currentWorkspaceSlug.value as string),
   ]);
   router.replace({
     name: 'project-settings',

--- a/src/modules/project-settings/general/ui/dialogs/DeleteProjectDialog.vue
+++ b/src/modules/project-settings/general/ui/dialogs/DeleteProjectDialog.vue
@@ -39,7 +39,6 @@ import { toRefs } from 'vue';
 import { useRouter } from 'vue-router';
 
 // stores
-import { useUserStore } from 'src/stores/user-store';
 import { useProjectStore } from 'src/stores/project-store';
 import { useWorkspaceStore } from 'src/stores/workspace-store';
 import { useNotificationStore } from 'src/stores/notification-store';
@@ -65,7 +64,6 @@ const emits = defineEmits<{
 
 const { currentProject: current_project } = toRefs(props);
 
-const userStore = useUserStore();
 const projectStore = useProjectStore();
 const workspaceStore = useWorkspaceStore();
 const { setNotificationView } = useNotificationStore();
@@ -76,28 +74,22 @@ const router = useRouter();
 
 const handleDeleteProject = async () => {
   emits('startLoading');
-  await deleteProject(
-    currentWorkspaceSlug.value as string,
-    currentProjectID.value,
-  )
-    .then(async () => {
-      await workspaceStore.getWorkspaceProjects(
-        currentWorkspaceSlug.value as string,
-      );
-      await userStore.getFavouriteProjects(
-        currentWorkspaceSlug.value as string,
-      );
+  try {
+    await deleteProject(
+      currentWorkspaceSlug.value as string,
+      currentProjectID.value,
+    );
 
-      router.push(`/${currentWorkspaceSlug.value}/`);
-      project.value = null;
+    router.push(`/${currentWorkspaceSlug.value}/`);
+    project.value = null;
 
-      setNotificationView({
-        type: 'success',
-        open: true,
-        customMessage: SUCCESS_DELETE_PROJECT,
-      });
-    })
-
-    .finally(() => emits('endLoading'));
+    setNotificationView({
+      type: 'success',
+      open: true,
+      customMessage: SUCCESS_DELETE_PROJECT,
+    });
+  } finally {
+    emits('endLoading');
+  }
 };
 </script>

--- a/src/stores/user-store.ts
+++ b/src/stores/user-store.ts
@@ -13,7 +13,6 @@ import {
   TypesActivityTable,
   DtoUserLight,
   DtoProjectLight,
-  DtoProjectFavorites,
   AiplanUserUpdateRequest,
   AiplanPasswordResponse,
   DtoEntityActivityFull,
@@ -29,7 +28,6 @@ interface IUserState {
   userActivity: DaoPaginationResponse;
   userActivityMap: TypesActivityTable;
   userProjects: DtoProjectLight[];
-  userFavouriteProjets: DtoProjectFavorites[];
   authToken: string;
 }
 
@@ -41,7 +39,6 @@ export const useUserStore = defineStore('user-store', {
       userActivity: {} as DaoPaginationResponse,
       userActivityMap: {} as TypesActivityTable,
       userProjects: [] as DtoProjectLight[],
-      userFavouriteProjets: [] as DtoProjectFavorites[],
       authToken: undefined as unknown as string,
     };
   },
@@ -144,14 +141,6 @@ export const useUserStore = defineStore('user-store', {
         this.userProjects = filters ? this.userProjects : res.data;
         return res.data;
       });
-    },
-
-    async getFavouriteProjects(workspaceSlug: string): Promise<void> {
-      if (!workspaceSlug || workspaceSlug === 'undefined') return;
-
-      await projectsApi
-        .getFavoriteProjects(workspaceSlug)
-        .then((res) => (this.userFavouriteProjets = res.data));
     },
 
     async addProjectToFavorites(

--- a/src/stores/workspace-store.ts
+++ b/src/stores/workspace-store.ts
@@ -159,6 +159,7 @@ export const useWorkspaceStore = defineStore('workspace-store', {
       },
       stopRefresh?: boolean,
     ): Promise<DtoProjectLight[] | void> {
+      console.log(workspaceSlug);
       if (!workspaceSlug || workspaceSlug === 'undefined') return;
 
       return projectsApi.getProjectList(workspaceSlug, filters).then((res) => {

--- a/src/stores/workspace-store.ts
+++ b/src/stores/workspace-store.ts
@@ -159,7 +159,6 @@ export const useWorkspaceStore = defineStore('workspace-store', {
       },
       stopRefresh?: boolean,
     ): Promise<DtoProjectLight[] | void> {
-      console.log(workspaceSlug);
       if (!workspaceSlug || workspaceSlug === 'undefined') return;
 
       return projectsApi.getProjectList(workspaceSlug, filters).then((res) => {


### PR DESCRIPTION
рефреш на фронте при удалении проекта уже был

в сервисе удаления проекта отсутствовал return, из-за чего промис резолвился сразу и запрос на получение проектов происходил раньше, чем успевал закончится запрос на удаление проекта

после удаления проекта в модалке были убраны запросы на получение проектов (потому что он дублирвоался сразу после перехода роутера, а также запрос на получение избранных проектов был полностью убран из юзер стора, он больше нигде не использовался
(избранные проекты уже учитываются в общем запросе на получение списка проектов)