### PR TITLE
fix: закрытие превью по клику в хлебных крошках BUGS-1209

### DIFF
--- a/src/components/headers/MainHeader.vue
+++ b/src/components/headers/MainHeader.vue
@@ -36,6 +36,7 @@
               : [breadCrumbsHistory[breadCrumbsHistory.length - 1]]"
             :key="index"
             :to="crumb?.url"
+            @click="crumb?.click?.()"
           >
             <HomeIcon
               v-if="!workspaceInfo?.logo && crumb?.type === 'workspace'"
@@ -198,6 +199,7 @@ const breadCrumbsHistory = computed(() => {
       name: ` ${project.value?.name ?? ''}`,
       url: `/${workspaceInfo.value?.slug}/projects/${project.value?.identifier || project.value?.id}`,
       type: 'project',
+      click: () => singleIssueStore.closePreview(),
     };
   else if (user.value && currentPath.includes('profile'))
     existPath[1] = {

--- a/src/stores/single-issue-store.ts
+++ b/src/stores/single-issue-store.ts
@@ -100,6 +100,10 @@ export const useSingleIssueStore = defineStore('single-issue-store', {
   },
 
   actions: {
+    closePreview() {
+      this.isPreview = false;
+      this.currentIssueID = '';
+    },
     async getIssueData(workspaceSlug: string, projectID: string) {
       await api
         .get(


### PR DESCRIPTION
Переход в проекты при открытом превью не осуществляется, потому что пользователь и так находится на странице проекта, это нормальное поведение vue-router
Добавил метод закрытия превью в стор, для хлебной крошки добавил действие по клику