### PR TITLE
feat: Дизейбл чекбоксов в диалогах при глобальном отключении уведомлений FRO-868

### DIFF
--- a/src/components/dialogs/NotificationsSettings/AdminSettingsList.vue
+++ b/src/components/dialogs/NotificationsSettings/AdminSettingsList.vue
@@ -1,6 +1,11 @@
 <template>
   <q-card class="setting-card">
-    <div class="sub-text q-ml-sm q-my-sm"><slot name="subtitle"></slot></div>
+    <div class="sub-text q-ml-sm q-my-sm">
+      <p v-if="disable" class="text-warning q-mb-sm">
+        Уведомления данного типа отключены глобально в профиле
+      </p>
+      <slot name="subtitle"></slot>
+    </div>
     <div class="notification-header">
       <span style="font-size: 14px; font-weight: 600">Название</span>
       <span style="text-align: center">Включить</span>
@@ -10,6 +15,7 @@
         <span class="centered-horisontally">Все</span>
         <q-checkbox
           class="justify-center"
+          :disable="disable"
           :model-value="allSettings"
           @update:model-value="(value: boolean) => setAll(!value)"
         />
@@ -22,6 +28,7 @@
         <span>{{ setting.title }}</span>
         <q-checkbox
           class="justify-center"
+          :disable="disable"
           :model-value="!settings[setting.field]"
           @update:model-value="
             (value: boolean) =>
@@ -39,6 +46,7 @@ import { computed } from 'vue';
 const props = defineProps<{
   settings: any;
   settingsList: { title: string; field: string }[];
+  disable?: boolean;
 }>();
 const emits = defineEmits<{ update: [{ field: string; value: boolean }] }>();
 
@@ -55,14 +63,12 @@ const setAll = (value: boolean) => {
 
 <style scoped lang="scss">
 .notification-setting {
-  display: flex;
-  width: 100%;
-  flex-direction: row;
-  flex-wrap: nowrap;
+  display: grid;
+  grid-template-columns: 3fr 1fr;
   align-items: center;
-  justify-content: space-between;
   margin-bottom: 8px;
 }
+
 .notification-list {
   max-height: calc(100vh - 400px);
   overflow-y: scroll;
@@ -77,7 +83,7 @@ const setAll = (value: boolean) => {
 
 .notification-header {
   display: grid;
-  grid-template-columns: 3fr 1fr 1fr;
+  grid-template-columns: 3fr 1fr;
   padding: 0px 8px;
 }
 
@@ -98,10 +104,5 @@ const setAll = (value: boolean) => {
     width: 100% !important;
     margin: 0px !important;
   }
-}
-
-.notification-setting {
-  display: grid;
-  grid-template-columns: 3fr 1fr 1fr;
 }
 </style>

--- a/src/components/dialogs/NotificationsSettings/BaseNotificationsSettingsDialog.vue
+++ b/src/components/dialogs/NotificationsSettings/BaseNotificationsSettingsDialog.vue
@@ -45,7 +45,6 @@
       </q-card-section>
       <q-card-actions class="notification-btns" align="right">
         <q-btn
-          :disable="isNotificationsDisabled"
           no-caps
           class="secondary-btn notification-btn"
           v-close-popup

--- a/src/components/dialogs/NotificationsSettings/BaseNotificationsSettingsDialog.vue
+++ b/src/components/dialogs/NotificationsSettings/BaseNotificationsSettingsDialog.vue
@@ -31,6 +31,7 @@
               <AdminSettingsList
                 :settings="settings[tab.field]"
                 :settingsList="settingsList"
+                :disable="isNotificationsDisabled"
                 @update="
                   (updatedField: { field: string; value: boolean }) =>
                     setCurrentSetting(updatedField, tab.field)
@@ -43,10 +44,15 @@
         </transition>
       </q-card-section>
       <q-card-actions class="notification-btns" align="right">
-        <q-btn no-caps class="secondary-btn notification-btn" v-close-popup
+        <q-btn
+          :disable="isNotificationsDisabled"
+          no-caps
+          class="secondary-btn notification-btn"
+          v-close-popup
           >Отмена</q-btn
         >
         <q-btn
+          :disable="isNotificationsDisabled"
           no-caps
           class="primary-btn notification-btn"
           @click="handleSaveSettings()"
@@ -65,12 +71,16 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue';
+import { computed, ref } from 'vue';
 
+import { storeToRefs } from 'pinia';
+import { useUserStore } from 'src/stores/user-store';
 import { useNotificationStore } from 'src/stores/notification-store';
 
 import DefaultLoader from '../../loaders/DefaultLoader.vue';
 import AdminSettingsList from './AdminSettingsList.vue';
+
+const { user } = storeToRefs(useUserStore());
 
 const loading = ref(false);
 const onLoad = () => getUserSettings();
@@ -82,6 +92,18 @@ const props = defineProps<{
 }>();
 
 const tab = ref('email');
+
+const isNotificationsDisabled = computed<boolean>(() => {
+  if (
+    (user.value.settings?.email_notification_mute && tab.value === 'email') ||
+    (user.value.settings?.telegram_notification_mute && tab.value === 'tg') ||
+    (user.value.settings?.app_notification_mute && tab.value === 'app')
+  ) {
+    return true;
+  } else {
+    return false;
+  }
+});
 
 const tabsConfig = [
   {

--- a/src/components/dialogs/NotificationsSettings/SettingList.vue
+++ b/src/components/dialogs/NotificationsSettings/SettingList.vue
@@ -1,6 +1,9 @@
 <template>
   <q-card class="setting-card">
-    <div class="sub-text q-ml-sm q-my-sm"><slot name="subtitle"></slot></div>
+    <div class="sub-text q-ml-sm q-my-sm">
+      <p v-if="disable" class="text-warning q-mb-sm">Уведомления данного типа отключены глобально в профиле</p>
+      <slot name="subtitle"></slot>
+    </div>
     <div class="notification-header">
       <div style="font-size: 14px; font-weight: 600">Название</div>
       <span style="text-align: center">Автор</span>
@@ -16,6 +19,7 @@
         <q-checkbox
           class="justify-center"
           v-model="emailAllSettings"
+          :disable="disable"
           @update:model-value="
             () => {
               setAllSettings(authorSetting, emailAllSettings);
@@ -26,6 +30,7 @@
         <q-checkbox
           class="justify-center"
           v-model="telegramAllSettings"
+          :disable="disable"
           @update:model-value="
             () => {
               setAllSettings(memberSettings, telegramAllSettings);
@@ -39,6 +44,7 @@
         <q-checkbox
           class="justify-center"
           v-model="authorSetting.disable_name"
+          :disable="disable"
           @update:model-value="
             emits('updateEmail', invertedSettings(authorSetting))
           "
@@ -46,6 +52,7 @@
         <q-checkbox
           class="justify-center"
           v-model="memberSettings.disable_name"
+          :disable="disable"
           @update:model-value="
             emits('updateTelegram', invertedSettings(memberSettings))
           "
@@ -56,6 +63,7 @@
         <q-checkbox
           class="justify-center"
           v-model="authorSetting.disable_desc"
+          :disable="disable"
           @update:model-value="
             emits('updateEmail', invertedSettings(authorSetting))
           "
@@ -63,6 +71,7 @@
         <q-checkbox
           class="justify-center"
           v-model="memberSettings.disable_desc"
+          :disable="disable"
           @update:model-value="
             emits('updateTelegram', invertedSettings(memberSettings))
           "
@@ -73,6 +82,7 @@
         <q-checkbox
           class="justify-center"
           v-model="authorSetting.disable_state"
+          :disable="disable"
           @update:model-value="
             emits('updateEmail', invertedSettings(authorSetting))
           "
@@ -80,6 +90,7 @@
         <q-checkbox
           class="justify-center"
           v-model="memberSettings.disable_state"
+          :disable="disable"
           @update:model-value="
             emits('updateTelegram', invertedSettings(memberSettings))
           "
@@ -91,6 +102,7 @@
         <q-checkbox
           class="justify-center"
           v-model="authorSetting.disable_assignees"
+          :disable="disable"
           @update:model-value="
             emits('updateEmail', invertedSettings(authorSetting))
           "
@@ -98,6 +110,7 @@
         <q-checkbox
           class="justify-center"
           v-model="memberSettings.disable_assignees"
+          :disable="disable"
           @update:model-value="
             emits('updateTelegram', invertedSettings(memberSettings))
           "
@@ -108,6 +121,7 @@
         <q-checkbox
           class="justify-center"
           v-model="authorSetting.disable_watchers"
+          :disable="disable"
           @update:model-value="
             emits('updateEmail', invertedSettings(authorSetting))
           "
@@ -115,6 +129,7 @@
         <q-checkbox
           class="justify-center"
           v-model="memberSettings.disable_watchers"
+          :disable="disable"
           @update:model-value="
             emits('updateTelegram', invertedSettings(memberSettings))
           "
@@ -125,6 +140,7 @@
         <q-checkbox
           class="justify-center"
           v-model="authorSetting.disable_priority"
+          :disable="disable"
           @update:model-value="
             emits('updateEmail', invertedSettings(authorSetting))
           "
@@ -132,6 +148,7 @@
         <q-checkbox
           class="justify-center"
           v-model="memberSettings.disable_priority"
+          :disable="disable"
           @update:model-value="
             emits('updateTelegram', invertedSettings(memberSettings))
           "
@@ -142,6 +159,7 @@
         <q-checkbox
           class="justify-center"
           v-model="authorSetting.disable_issue_new"
+          :disable="disable"
           @update:model-value="
             emits('updateEmail', invertedSettings(authorSetting))
           "
@@ -149,6 +167,7 @@
         <q-checkbox
           class="justify-center"
           v-model="memberSettings.disable_issue_new"
+          :disable="disable"
           @update:model-value="
             emits('updateTelegram', invertedSettings(memberSettings))
           "
@@ -159,6 +178,7 @@
         <q-checkbox
           class="justify-center"
           v-model="authorSetting.disable_parent"
+          :disable="disable"
           @update:model-value="
             emits('updateEmail', invertedSettings(authorSetting))
           "
@@ -166,6 +186,7 @@
         <q-checkbox
           class="justify-center"
           v-model="memberSettings.disable_parent"
+          :disable="disable"
           @update:model-value="
             emits('updateTelegram', invertedSettings(memberSettings))
           "
@@ -176,6 +197,7 @@
         <q-checkbox
           class="justify-center"
           v-model="authorSetting.disable_blocks"
+          :disable="disable"
           @update:model-value="
             emits('updateEmail', invertedSettings(authorSetting))
           "
@@ -183,6 +205,7 @@
         <q-checkbox
           class="justify-center"
           v-model="memberSettings.disable_blocks"
+          :disable="disable"
           @update:model-value="
             emits('updateTelegram', invertedSettings(memberSettings))
           "
@@ -193,6 +216,7 @@
         <q-checkbox
           class="justify-center"
           v-model="authorSetting.disable_blockedBy"
+          :disable="disable"
           @update:model-value="
             emits('updateEmail', invertedSettings(authorSetting))
           "
@@ -200,6 +224,7 @@
         <q-checkbox
           class="justify-center"
           v-model="memberSettings.disable_blockedBy"
+          :disable="disable"
           @update:model-value="
             emits('updateTelegram', invertedSettings(memberSettings))
           "
@@ -210,6 +235,7 @@
         <q-checkbox
           class="justify-center"
           v-model="authorSetting.disable_targetDate"
+          :disable="disable"
           @update:model-value="
             emits('updateEmail', invertedSettings(authorSetting))
           "
@@ -217,6 +243,7 @@
         <q-checkbox
           class="justify-center"
           v-model="memberSettings.disable_targetDate"
+          :disable="disable"
           @update:model-value="
             emits('updateTelegram', invertedSettings(memberSettings))
           "
@@ -227,6 +254,7 @@
         <q-checkbox
           class="justify-center"
           v-model="authorSetting.disable_labels"
+          :disable="disable"
           @update:model-value="
             emits('updateEmail', invertedSettings(authorSetting))
           "
@@ -234,6 +262,7 @@
         <q-checkbox
           class="justify-center"
           v-model="memberSettings.disable_labels"
+          :disable="disable"
           @update:model-value="
             emits('updateTelegram', invertedSettings(memberSettings))
           "
@@ -244,6 +273,7 @@
         <q-checkbox
           class="justify-center"
           v-model="authorSetting.disable_links"
+          :disable="disable"
           @update:model-value="
             emits('updateEmail', invertedSettings(authorSetting))
           "
@@ -251,6 +281,7 @@
         <q-checkbox
           class="justify-center"
           v-model="memberSettings.disable_links"
+          :disable="disable"
           @update:model-value="
             emits('updateTelegram', invertedSettings(memberSettings))
           "
@@ -261,6 +292,7 @@
         <q-checkbox
           class="justify-center"
           v-model="authorSetting.disable_comments"
+          :disable="disable"
           @update:model-value="
             emits('updateEmail', invertedSettings(authorSetting))
           "
@@ -268,6 +300,7 @@
         <q-checkbox
           class="justify-center"
           v-model="memberSettings.disable_comments"
+          :disable="disable"
           @update:model-value="
             emits('updateTelegram', invertedSettings(memberSettings))
           "
@@ -278,6 +311,7 @@
         <q-checkbox
           class="justify-center"
           v-model="authorSetting.disable_attachments"
+          :disable="disable"
           @update:model-value="
             emits('updateEmail', invertedSettings(authorSetting))
           "
@@ -285,6 +319,7 @@
         <q-checkbox
           class="justify-center"
           v-model="memberSettings.disable_attachments"
+          :disable="disable"
           @update:model-value="
             emits('updateTelegram', invertedSettings(memberSettings))
           "
@@ -295,6 +330,7 @@
         <q-checkbox
           class="justify-center"
           v-model="authorSetting.disable_issue_transfer"
+          :disable="disable"
           @update:model-value="
             emits('updateEmail', invertedSettings(authorSetting))
           "
@@ -302,6 +338,7 @@
         <q-checkbox
           class="justify-center"
           v-model="memberSettings.disable_issue_transfer"
+          :disable="disable"
           @update:model-value="
             emits('updateTelegram', invertedSettings(memberSettings))
           "
@@ -312,6 +349,7 @@
         <q-checkbox
           class="justify-center"
           v-model="authorSetting.disable_sub_issue"
+          :disable="disable"
           @update:model-value="
             emits('updateEmail', invertedSettings(authorSetting))
           "
@@ -319,6 +357,7 @@
         <q-checkbox
           class="justify-center"
           v-model="memberSettings.disable_sub_issue"
+          :disable="disable"
           @update:model-value="
             emits('updateTelegram', invertedSettings(memberSettings))
           "
@@ -329,6 +368,7 @@
         <q-checkbox
           class="justify-center"
           v-model="authorSetting.disable_linked"
+          :disable="disable"
           @update:model-value="
             emits('updateEmail', invertedSettings(authorSetting))
           "
@@ -336,6 +376,7 @@
         <q-checkbox
           class="justify-center"
           v-model="memberSettings.disable_linked"
+          :disable="disable"
           @update:model-value="
             emits('updateTelegram', invertedSettings(memberSettings))
           "
@@ -346,6 +387,7 @@
         <q-checkbox
           class="justify-center"
           v-model="authorSetting.disable_deadline"
+          :disable="disable"
           @update:model-value="
             emits('updateEmail', invertedSettings(authorSetting))
           "
@@ -353,6 +395,7 @@
         <q-checkbox
           class="justify-center"
           v-model="memberSettings.disable_deadline"
+          :disable="disable"
           @update:model-value="
             emits('updateTelegram', invertedSettings(memberSettings))
           "
@@ -378,7 +421,12 @@ const emits = defineEmits<{
   updateEmail: [value: IProjectNotificationSettings];
 }>();
 
-const props = defineProps(['project', 'authorSettings', 'memberSettings']);
+const props = defineProps([
+  'project',
+  'authorSettings',
+  'memberSettings',
+  'disable',
+]);
 
 const emailAllSettings = ref(false);
 const telegramAllSettings = ref(false);

--- a/src/components/dialogs/NotificationsSettingsDialog.vue
+++ b/src/components/dialogs/NotificationsSettingsDialog.vue
@@ -28,6 +28,7 @@
                 :project="props.project.id"
                 :authorSettings="settings.notification_author_settings_email"
                 :memberSettings="settings.notification_settings_email"
+                :disable="user.settings?.email_notification_mute"
                 @updateTelegram="
                   (value) =>
                     setCurrentSetting(value, 'notification_settings_email')
@@ -76,6 +77,7 @@
                 :project="props.project.id"
                 :authorSettings="settings.notification_author_settings_tg"
                 :memberSettings="settings.notification_settings_tg"
+                :disable="user.settings?.telegram_notification_mute"
                 @updateTelegram="
                   (value) =>
                     setCurrentSetting(value, 'notification_settings_tg')
@@ -115,6 +117,7 @@
                 :project="props.project.id"
                 :authorSettings="settings.notification_author_settings_app"
                 :memberSettings="settings.notification_settings_app"
+                :disable="user.settings?.app_notification_mute"
                 @updateTelegram="
                   (value) =>
                     setCurrentSetting(value, 'notification_settings_app')
@@ -152,10 +155,15 @@
         </transition>
       </q-card-section>
       <q-card-actions class="notification-btns" align="right">
-        <q-btn no-caps class="secondary-btn notification-btn" v-close-popup
+        <q-btn
+          :disable="isButtonDisabled"
+          no-caps
+          class="secondary-btn notification-btn"
+          v-close-popup
           >Отмена</q-btn
         >
         <q-btn
+          :disable="isButtonDisabled"
           no-caps
           class="primary-btn notification-btn"
           @click="handleSaveSettings()"
@@ -176,12 +184,13 @@
 <script setup lang="ts">
 // core
 import { storeToRefs } from 'pinia';
-import { onMounted, ref, watch } from 'vue';
+import { computed, onMounted, ref, watch } from 'vue';
 
 // stores
 import { useProjectStore } from 'src/stores/project-store';
 import { useWorkspaceStore } from 'src/stores/workspace-store';
 import { useNotificationStore } from 'src/stores/notification-store';
+import { useUserStore } from 'src/stores/user-store';
 
 import SettingList from './NotificationsSettings/SettingList.vue';
 import AidocNotificationsSettings from '../aidoc/AidocNotificationsSettings.vue';
@@ -193,6 +202,7 @@ import DefaultLoader from '../loaders/DefaultLoader.vue';
 const projectStore = useProjectStore();
 const workspaceStore = useWorkspaceStore();
 const { setNotificationView } = useNotificationStore();
+const { user } = storeToRefs(useUserStore());
 
 const { currentWorkspaceSlug } = storeToRefs(workspaceStore);
 
@@ -203,6 +213,18 @@ const props = defineProps<{
 
 const dialogRef = ref();
 const tab = ref('email');
+
+const isButtonDisabled = computed<boolean>(() => {
+  if (
+    (user.value.settings?.email_notification_mute && tab.value === 'email') ||
+    (user.value.settings?.telegram_notification_mute && tab.value === 'tg') ||
+    (user.value.settings?.app_notification_mute && tab.value === 'app')
+  ) {
+    return true;
+  } else {
+    return false;
+  }
+});
 
 const settings = ref({
   notification_author_settings_email: {},
@@ -241,7 +263,7 @@ const loadSettings = async () => {
   } else {
     await getProjectUser();
   }
-}
+};
 
 const getProjectUser = async () => {
   if (!props.project?.id) return;

--- a/src/components/dialogs/NotificationsSettingsDialog.vue
+++ b/src/components/dialogs/NotificationsSettingsDialog.vue
@@ -156,7 +156,6 @@
       </q-card-section>
       <q-card-actions class="notification-btns" align="right">
         <q-btn
-          :disable="isButtonDisabled"
           no-caps
           class="secondary-btn notification-btn"
           v-close-popup


### PR DESCRIPTION
Добавлен дизейбл кнопок и чекбоксов в диалоговых окнах настройки уведомлений при глобальном отключении уведомлений в настройках.
Дизейбл добавлен в диалоговых окнах настроек пространства, проекта, задачи.
<img width="590" height="686" alt="изображение" src="https://github.com/user-attachments/assets/c8fc334a-337b-49d4-8860-23f7edb629e9" />

Также исправлено визуальное некорректное смещение столбца в окне, когда чекбоксы располагались посередине и при этом справа от них оставалось много пустого места.