### PR TITLE
fix: Исправлена ширина кнопки FRO-830

### DIFF
--- a/src/components/dialogs/AIDocDialogs/HierarchyDocDialog.vue
+++ b/src/components/dialogs/AIDocDialogs/HierarchyDocDialog.vue
@@ -31,7 +31,7 @@
           flat
           no-caps
           label="Отмена"
-          class="btn"
+          class="btn secondary-btn"
           color="negative"
           @click="clearChanges"
           :disable="!isSaving"

--- a/src/components/dialogs/AIDocDialogs/HierarchyDocDialog.vue
+++ b/src/components/dialogs/AIDocDialogs/HierarchyDocDialog.vue
@@ -31,7 +31,7 @@
           flat
           no-caps
           label="Отмена"
-          class="btn secondary-btn"
+          class="btn secondary-btn doc-hierarchy-btn"
           color="negative"
           @click="clearChanges"
           :disable="!isSaving"
@@ -40,7 +40,7 @@
           flat
           no-caps
           label="Сохранить"
-          class="btn primary-btn"
+          class="btn primary-btn doc-hierarchy-btn"
           color="primary"
           @click="saveChanges"
           :disable="!isSaving"
@@ -394,6 +394,10 @@ watch(
   @media screen and (width < 600px) {
     width: 90vw;
   }
+}
+
+.doc-hierarchy-btn {
+  min-width: 103px !important;
 }
 
 .nested {


### PR DESCRIPTION
Кнопки с нижней панели диалогового окна иерархии теперь имеют одинаковую ширину