### PR TITLE
fix: в список проектов для переноса добавлены проекты, в которых пользователь участник FRO-805

### DIFF
--- a/src/constants/roles.ts
+++ b/src/constants/roles.ts
@@ -106,6 +106,7 @@ export const ROLES = {
       'show-project',
       'change-issue-status',
       'add-to-fav',
+      'transfer-issue',
     ],
     guest: ['show-project-popup', 'show-project', 'show-comment', 'add-to-fav'],
   },


### PR DESCRIPTION
Раньше задачи можно было переносить только в проекты, в которых пользователь является админом или овнером
Добавлена такая же возможность для проектов, в которых пользователь является участником