### PR TITLE
fix: убраны бесконечные запросы на projects и алерт срока теперь у подзадачи FRO-883

### DIFF
--- a/src/components/NewIssue.vue
+++ b/src/components/NewIssue.vue
@@ -112,8 +112,6 @@ const isDisabled = computed(() => {
     return wsRole < 10;
   }
 
-  workspaceStore.getWorkspaceProjects(wsSlug);
-
   if (workspaceProjects.value.length === 0) {
     return true;
   }
@@ -158,7 +156,8 @@ watch(
   },
 );
 
-onMounted(() => {
+onMounted(async () => {
+  await workspaceStore.getWorkspaceProjects(currentWorkspaceSlug?.value ?? '');
   emits('setDisable', isDisabled.value);
 });
 </script>

--- a/src/components/issue-panels/SingleIssueDrawer.vue
+++ b/src/components/issue-panels/SingleIssueDrawer.vue
@@ -496,12 +496,13 @@ const { currentWorkspaceSlug, workspaceInfo } = storeToRefs(workspaceStore);
 
 const props = defineProps<{
   preview?: boolean;
-  subIssues?: DtoIssue[];
 }>();
 
 const emits = defineEmits<{
   refresh: [isFullRefresh?: boolean];
 }>();
+
+const parentIssueData = ref<DtoIssue>();
 
 const { navigateToActivityPage } = useUserActivityNavigation();
 
@@ -511,10 +512,8 @@ const hideSettings = computed(() => {
 
 const isSubIssueTargetOverTime = computed(
   () =>
-    props.subIssues?.some(
-      (issue) =>
-        issue.target_date && issue.target_date > issueData.value.target_date,
-    ) ?? false,
+    parentIssueData.value?.target_date &&
+    issueData.value.target_date > parentIssueData.value?.target_date,
 );
 
 //refs
@@ -523,6 +522,7 @@ const refreshCycle = ref();
 // functions
 const handleRefresh = async () => {
   await refresh();
+  await updateParentIssueData();
   emits('refresh');
 };
 
@@ -664,8 +664,21 @@ const handleLinkEdit = async (link: DtoIssueLinkLight) => {
   });
 };
 
-onMounted(() => {
+const updateParentIssueData = async () => {
+  if (issueData.value.parent) {
+    parentIssueData.value = (
+      await singleIssueStore.getIssueDataById(
+        currentWorkspaceSlug.value,
+        issueData.value.project ?? currentProjectID.value,
+        issueData.value.parent,
+      )
+    ).data;
+  }
+};
+
+onMounted(async () => {
   refreshCycle.value = setIntervalFunction(refresh);
+  await updateParentIssueData();
 });
 
 onBeforeUnmount(() => {

--- a/src/modules/single-issue/preview-issue/ui/IssuePreview.vue
+++ b/src/modules/single-issue/preview-issue/ui/IssuePreview.vue
@@ -65,7 +65,6 @@
         :project="issueData.project_detail"
         :issueid="issueData.id"
         :is-disabled="hasPermissionByIssue(issueData, 'add-sub-issue')"
-        @get-sub-issues="(issues) => (subIssues = issues)"
       />
       <LinkedIssuesPanel :project_detail="issueData.project_detail" />
 
@@ -88,7 +87,6 @@
       preview
       class="fixed-right hide-scrollbar issue-drawer-preview"
       style="top: 62px"
-      :sub-issues="subIssues"
       @refresh="(v) => refreshData(v)"
     />
   </q-drawer>
@@ -130,7 +128,6 @@ import MainIssueInfo from '../../main-issue-info/ui/MainIssueInfo.vue';
 import { QUASAR_SELECTORS_CLASSES } from 'src/constants/quasarSelectorsClasses';
 import { useDrawerResize } from 'src/composables/useDrawerResize';
 import { useUIStore } from 'src/stores/ui-store';
-import { DtoIssue } from '@aisa-it/aiplan-api-ts/src/data-contracts';
 
 const model = defineModel<boolean>({ default: false });
 
@@ -169,8 +166,6 @@ const { adaptiveWidth, onPointerDown, updateClientWidth } = useDrawerResize(
   'drawerWidth',
   'right',
 );
-
-const subIssues = ref<DtoIssue[]>([]);
 
 const hideSettings = computed(() => {
   return project.value?.hide_fields ?? [];

--- a/src/modules/single-issue/sub-issues/ui/SubIssuesPanel.vue
+++ b/src/modules/single-issue/sub-issues/ui/SubIssuesPanel.vue
@@ -60,10 +60,7 @@ import IssuesExpansionItem from 'src/modules/single-issue/ui/components/IssuesEx
 import { useSingleIssueStore } from 'src/stores/single-issue-store';
 
 import { setIntervalFunction } from 'src/utils/helpers';
-import {
-  DtoIssue,
-  DtoProject,
-} from '@aisa-it/aiplan-api-ts/src/data-contracts';
+import { DtoProject } from '@aisa-it/aiplan-api-ts/src/data-contracts';
 
 const props = defineProps<{
   project?: DtoProject;
@@ -75,8 +72,6 @@ const props = defineProps<{
     default: () => false;
   };
 }>();
-
-const emits = defineEmits<{ getSubIssues: [DtoIssue[]] }>();
 
 //core
 const route = useRoute();
@@ -102,7 +97,6 @@ const refresh = async () => {
   );
 
   subIssues.value = data?.sub_issues;
-  emits('getSubIssues', data?.sub_issues);
   stateDistribution.value = data?.state_distribution;
 };
 

--- a/src/modules/single-issue/ui/IssuePanel.vue
+++ b/src/modules/single-issue/ui/IssuePanel.vue
@@ -7,7 +7,7 @@
       class="issue-side-drawer q-ml-sm issue-panel-card hide-scrollbar"
       :width="dynamicWidthDrawer"
     >
-      <SingleIssueDrawer :sub-issues="subIssues" />
+      <SingleIssueDrawer />
     </q-drawer>
 
     <q-page-container class="flex-grow">
@@ -22,7 +22,6 @@
           :project="issueData.project_detail"
           :issueid="issueData.id"
           :is-disabled="hasPermissionByIssue(issueData, 'add-sub-issue')"
-          @get-sub-issues="(issues) => (subIssues = issues)"
         />
         <LinkedIssuesPanel />
 
@@ -64,7 +63,6 @@ import SingleIssueActivity from 'src/components/issue-panels/SingleIssueActivity
 import { MainIssueInfo } from 'src/modules/single-issue/main-issue-info';
 import LinkedIssuesPanel from '../linked-issues/ui/LinkedIssuesPanel.vue';
 import { FileAttUploadProgressFunc } from 'src/interfaces/files';
-import { DtoIssue } from '@aisa-it/aiplan-api-ts/src/data-contracts';
 
 // emits: ['update:issuePage'],
 // stores
@@ -82,8 +80,6 @@ const { currentWorkspaceSlug } = storeToRefs(workspaceStore);
 const rightDrawerOpen = ref(Screen.width > 1323);
 
 const selectAttachments = ref();
-
-const subIssues = ref<DtoIssue[]>([]);
 
 // блок вложений
 const getAttachmentsList = async () => {


### PR DESCRIPTION
Исправлен баг с бесконечным вызовом запроса на проекты, происходил из-за того, что вызов запроса происходил в computed, перенес вызов запроса в onMount
Предупреждение о сроке задачи теперь показывается не у родителя, а у подзадачи, у которой срок больше, чем у родительской