### PR TITLE
feat: рефакторинг компонента выбора статусов и его родителей FRO-898

### DIFF
--- a/src/components/NewIssuePanel.vue
+++ b/src/components/NewIssuePanel.vue
@@ -95,11 +95,13 @@
             <CheckStatusIcon class="issue-selector-icon mr-12" />
 
             <select-status
-              :projectid="project.id || ''"
               v-model:status="status"
-              @updateInitialStatus="(s: any) => (status = s)"
+              :items="items"
+              :loading="isLoading"
+              :error="statesError"
               label="Выберите статус"
               class="col centered-horisontally"
+              @popup-show="loadItems(project.id || '')"
             ></select-status>
           </div>
         </div>
@@ -307,6 +309,7 @@ import {
 
 //composables
 import { useSingleIssueTemplate } from 'src/modules/single-issue/linked-issues/composables/useSingleIssueTemplate';
+import { useStatusSelect } from 'src/composables/useStatusSelect';
 import { useRouter } from 'vue-router';
 
 // components
@@ -379,6 +382,8 @@ const singleIssueStore = useSingleIssueStore();
 const sprintStore = useSprintStore();
 const { setNotificationView } = useNotificationStore();
 const { hasPermissionByWorkspace, getProjectRole } = useRolesStore();
+const { items, isLoading, error: statesError, loadItems, resetItems } =
+  useStatusSelect();
 
 //storesToRefs
 const { currentWorkspaceSlug, workspaceInfo } = storeToRefs(workspaceStore);
@@ -725,6 +730,16 @@ watch(
     if (newValue?.id !== oldValue?.id) parent.value = null;
     if (project.value?.id)
       fetchTemplates(workspaceSlug.value, project.value?.id);
+  },
+);
+
+watch(
+  () => project.value?.id,
+  async (id) => {
+    if (!id) return;
+    resetItems();
+    await loadItems(id);
+    status.value = items.value.find((s) => s.default) || items.value[0] || null;
   },
 );
 

--- a/src/components/SelectStatus.vue
+++ b/src/components/SelectStatus.vue
@@ -7,28 +7,36 @@
     v-model="open"
     no-wrap
     no-caps
-    :options="states"
+    :options="items"
     :option-label="(v) => v.name"
     :option-value="(v) => v.id"
     :class="`${issue ? 'base-selector-sm' : 'base-selector'} ${isAdaptiveSelect ? 'adaptive-select' : ''}`"
     :style="{ width: isAdaptiveSelect ? '' : '160px' }"
     dense
-    @popup-show="
-      () => {
-        refresh();
-        emits('popup-show');
-      }
-    "
+    @popup-show="emits('popup-show')"
     @popup-hide="emits('popup-hide')"
   >
-    <template v-slot:no-option></template>
+    <template v-slot:no-option>
+      <div
+        v-if="loading"
+        class="row justify-center items-center q-pa-sm"
+      >
+        <q-spinner color="primary" size="24px" />
+      </div>
+      <div
+        v-else-if="error"
+        class="q-pa-md text-center text-white"
+      >
+        {{ error }}
+      </div>
+    </template>
     <template v-slot:option="scope">
       <q-item
         clickable
         v-close-popup
         :key="scope.opt.id"
         class="word-wrap"
-        @click="async () => await issueStateUpdate(scope.opt)"
+        @click="emits('update:status', scope.opt)"
       >
         <q-item-section>
           <div class="full-w" style="display: flex; align-items: center">
@@ -62,191 +70,39 @@
 </template>
 
 <script setup lang="ts">
-// core
-import { storeToRefs } from 'pinia';
-import { onMounted, ref, watch } from 'vue';
-
-// store
-import { useAiplanStore } from 'src/stores/aiplan-store';
-import { useStatesStore } from 'src/stores/states-store';
-import {
-  NotUpdated,
-  useSprintStore,
-} from 'src/modules/sprints/stores/sprint-store';
-import { useWorkspaceStore } from 'src/stores/workspace-store';
-import { useSingleIssueStore } from 'src/stores/single-issue-store';
-import { useNotificationStore } from 'src/stores/notification-store';
-import { useIssuesStatesFlowStore } from 'src/stores/issues-states-flow-store';
-import { useProjectStatesFlowStore } from 'src/stores/project-states-flow-store';
-
-// utils
+import { ref, watch } from 'vue';
 import { useResizeObserverSelect } from 'src/utils/useResizeObserverSelect';
-
-// interfaces
-import { IState } from 'src/interfaces/states';
 import type { DtoStateLight } from '@aisa-it/aiplan-api-ts/src/data-contracts';
-import { isObjectsEqual } from 'src/utils/helpers';
 
 defineOptions({
   name: 'SelectStatus',
 });
 
 const props = defineProps<{
-  projectid: string;
-  issueid?: string;
   status?: {
     id?: string;
     color?: string;
     name?: string;
   };
-  issue?: {
-    project_detail?: unknown;
-  };
-  statesFromCache?: Record<string, IState[]>;
+  items?: DtoStateLight[];
+  issue?: unknown;
   isAdaptiveSelect?: boolean;
   isDisabled?: boolean;
   label?: string;
+  loading?: boolean;
+  error?: string;
 }>();
 
 const emits = defineEmits<{
-  setStatus: [IState];
-  'update-initial-status': [IState];
-  'update:status': [IState];
-  refresh: [];
+  'update:status': [DtoStateLight];
   'popup-show': [];
   'popup-hide': [];
 }>();
 
-useAiplanStore();
-const statesStore = useStatesStore();
-const workspaceStore = useWorkspaceStore();
-const singleIssueStore = useSingleIssueStore();
-const { setNotificationView } = useNotificationStore();
-const issuesStatesFlowStore = useIssuesStatesFlowStore();
-const projectStatesFlowStore = useProjectStatesFlowStore();
-
-const { currentWorkspaceSlug } = storeToRefs(workspaceStore);
-
-const states = ref<IState[]>([]);
 const open = ref();
 
 const selectStatusRef = ref();
 useResizeObserverSelect(selectStatusRef);
-
-const refresh = async () => {
-  const workspaceSlug = currentWorkspaceSlug.value;
-  const { data } = props.issue?.project_detail
-    ? { data: props.statesFromCache }
-    : await statesStore.getStatesByProject(workspaceSlug, props.projectid);
-  let arr: IState[] = [];
-  for (const n in data) {
-    arr = arr.concat(data[n]);
-  }
-  // Ограничиваем список переходов по бизнес-процессу (если ручка доступна).
-  // Фолбэк: если ручка недоступна/пусто/ошибка — показываем все статусы.
-  if (currentWorkspaceSlug.value) {
-    try {
-      if (props.issueid) {
-        const available = await issuesStatesFlowStore.getAvailableStates(
-          currentWorkspaceSlug.value,
-          props.projectid,
-          props.issueid,
-        );
-        arr = filterStatesByAllowedTransitions(
-          arr,
-          available,
-          props.status?.id,
-        );
-      } else {
-        const available =
-          await projectStatesFlowStore.getAvailableStatesNewIssue(
-            currentWorkspaceSlug.value,
-            props.projectid,
-          );
-        arr = filterStatesByAllowedTransitions(
-          arr,
-          available,
-          props.status?.id,
-        );
-      }
-    } catch (e) {
-      // ignore
-    }
-  }
-
-  states.value = arr;
-
-  if (!props.status) {
-    emits(
-      'update-initial-status',
-      arr.find((status) => status.default === true) || arr[0],
-    );
-  }
-};
-
-const filterStatesByAllowedTransitions = (
-  states: IState[],
-  available: DtoStateLight[],
-  currentStatusId: string | undefined,
-) => {
-  const allowedIds = new Set(available.map((s) => s.id));
-  if (!allowedIds.size) return states;
-  return states.filter((s) => allowedIds.has(s.id) || s.id === currentStatusId);
-};
-
-const showNotification = (type: 'success' | 'error', msg?: string) => {
-  setNotificationView({
-    open: true,
-    type: type,
-    customMessage: msg,
-  });
-};
-
-const issueStateUpdate = async (state: IState) => {
-  if (state.id === props.status?.id) return;
-
-  if (!props.issueid) {
-    emits('update:status', state);
-  } else {
-    if (!currentWorkspaceSlug.value) return;
-    await singleIssueStore
-      .updateIssueData(
-        currentWorkspaceSlug.value,
-        props.projectid,
-        props.issueid,
-        {
-          state: state.id,
-        },
-      )
-      .then(() => {
-        refresh();
-        useSprintStore().triggerSprintRefresh(NotUpdated.SprintPage);
-        showNotification('success');
-        emits('setStatus', state);
-        emits('refresh');
-      });
-  }
-};
-
-onMounted(() => {
-  if (!props.issueid) {
-    refresh();
-  }
-});
-
-watch(
-  () => props.projectid,
-  () => refresh(),
-);
-
-watch(
-  () => props.statesFromCache,
-  (newVal, oldVal) => {
-    if (!isObjectsEqual(newVal, oldVal)) {
-      refresh();
-    }
-  },
-);
 
 watch(
   () => props.status,

--- a/src/components/dialogs/TransferTaskDialogs/TransferTaskParameters.vue
+++ b/src/components/dialogs/TransferTaskDialogs/TransferTaskParameters.vue
@@ -28,23 +28,16 @@
           <div class="col flex rounded-borders">
             <SelectStatus
               class="issue-selector full-w"
-              :projectid="props.project_id"
               :status="issueSettings.state_detail"
+              :items="items"
+              :loading="isLoading"
+              :error="statesError"
               :isDisabled="
                 !hasPermissionByIssue(issueData, 'change-issue-status')
               "
               isAdaptiveSelect
-              :states-from-cache="statesCache[issueData?.project]"
-              @update:status="
-                (val) => {
-                  return (issueSettings.state_detail = val);
-                }
-              "
-              @updateInitialStatus="
-                (val) => {
-                  return (issueSettings.state_detail = val);
-                }
-              "
+              @popup-show="loadItems(project_id)"
+              @update:status="(val) => (issueSettings.state_detail = val)"
             />
           </div>
         </div>
@@ -219,6 +212,7 @@ import { useProjectStore } from 'src/stores/project-store';
 import { useStatesStore } from 'src/stores/states-store';
 import { useWorkspaceStore } from 'src/stores/workspace-store';
 import { useUserStore } from 'src/stores/user-store';
+import { useStatusSelect } from 'src/composables/useStatusSelect';
 import {
   DtoIssue,
   DtoProjectMemberLight,
@@ -231,7 +225,7 @@ const projectStore = useProjectStore();
 const { hasPermissionByIssue } = useRolesStore();
 const statesStore = useStatesStore();
 const workspaceStore = useWorkspaceStore();
-const { statesCache } = storeToRefs(statesStore);
+const { items, isLoading, error: statesError, loadItems } = useStatusSelect();
 
 // store to refs
 const { user } = storeToRefs(userStore);

--- a/src/components/issue-panels/SingleIssueDrawer.vue
+++ b/src/components/issue-panels/SingleIssueDrawer.vue
@@ -21,16 +21,16 @@
         <div class="col flex rounded-borders">
           <SelectStatus
             class="issue-selector full-w"
-            :projectid="issueData.project"
-            :issueid="issueData.id"
             :issue="issueData"
             :status="issueData.state_detail"
+            :items="items"
+            :loading="isLoading"
+            :error="statesError"
             :isDisabled="
               !hasPermissionByIssue(issueData, 'change-issue-status')
             "
-            :states-from-cache="statesCache[issueData?.project]"
-            @set-status="(val) => (issueData.state_detail = val)"
-            @refresh="handleRefresh"
+            @popup-show="loadItems(issueData.project, issueData.id)"
+            @update:status="onUpdateStatus"
           />
         </div>
       </div>
@@ -420,7 +420,6 @@ import { storeToRefs } from 'pinia';
 // stores
 import { useUserStore } from 'src/stores/user-store';
 import { useRolesStore } from 'src/stores/roles-store';
-import { useStatesStore } from 'src/stores/states-store';
 import { useProjectStore } from 'src/stores/project-store';
 import { useWorkspaceStore } from 'src/stores/workspace-store';
 import { useSingleIssueStore } from 'src/stores/single-issue-store';
@@ -432,6 +431,7 @@ import { formatDateTime, msToRussianTime } from 'src/utils/time';
 
 // composables
 import { useUserActivityNavigation } from 'src/composables/useUserActivityNavigation';
+import { useStatusSelect } from 'src/composables/useStatusSelect';
 
 // components - core
 import AvatarImage from 'src/components/AvatarImage.vue';
@@ -477,21 +477,22 @@ import { setIntervalFunction } from 'src/utils/helpers';
 import {
   DtoIssue,
   DtoIssueLinkLight,
+  DtoStateLight,
 } from '@aisa-it/aiplan-api-ts/src/data-contracts';
 
 // stores
 const userStore = useUserStore();
-const statesStore = useStatesStore();
 const projectStore = useProjectStore();
 const { hasPermissionByIssue, hasPermissionByWorkspace } = useRolesStore();
 const workspaceStore = useWorkspaceStore();
 const singleIssueStore = useSingleIssueStore();
 const { setNotificationView } = useNotificationStore();
+const { items, isLoading, error: statesError, loadItems, updateStatus } =
+  useStatusSelect();
 
 // store to refs
 const { user } = storeToRefs(userStore);
 const { currentProjectID, project } = storeToRefs(projectStore);
-const { statesCache } = storeToRefs(statesStore);
 const { currentIssueID, issueData } = storeToRefs(singleIssueStore);
 const { currentWorkspaceSlug, workspaceInfo } = storeToRefs(workspaceStore);
 
@@ -521,6 +522,14 @@ const isSubIssueTargetOverTime = computed(
 const refreshCycle = ref();
 
 // functions
+const onUpdateStatus = async (state: DtoStateLight) => {
+  if (state.id === issueData.value.state_detail?.id) return;
+
+  await updateStatus(issueData.value.project, issueData.value.id, state);
+  issueData.value.state_detail = state;
+  handleRefresh();
+};
+
 const handleRefresh = async () => {
   await refresh();
   await updateParentIssueData();

--- a/src/composables/useStatusSelect.ts
+++ b/src/composables/useStatusSelect.ts
@@ -26,22 +26,26 @@ export function useStatusSelect() {
 
     const workspaceSlug = currentWorkspaceSlug.value ?? '';
 
-    isLoading.value = true;
     error.value = '';
+
+    const loaderTimeout = setTimeout(() => (isLoading.value = true), 300);
     try {
-      items.value = issueId
-        ? await issuesStatesFlowStore.getAvailableStates(
-            workspaceSlug,
-            projectId,
-            issueId,
-          )
-        : await projectStatesFlowStore.getAvailableStatesNewIssue(
-            workspaceSlug,
-            projectId,
-          );
+      if (issueId) {
+        items.value = await issuesStatesFlowStore.getAvailableStates(
+          workspaceSlug,
+          projectId,
+          issueId,
+        );
+      } else {
+        items.value = await projectStatesFlowStore.getAvailableStatesNewIssue(
+          workspaceSlug,
+          projectId,
+        );
+      }
     } catch (e) {
       error.value = 'Не удалось получить актуальные статусы';
     } finally {
+      clearTimeout(loaderTimeout);
       isLoading.value = false;
     }
   };

--- a/src/composables/useStatusSelect.ts
+++ b/src/composables/useStatusSelect.ts
@@ -1,0 +1,68 @@
+import { ref } from 'vue';
+import { storeToRefs } from 'pinia';
+import type { DtoStateLight } from '@aisa-it/aiplan-api-ts/src/data-contracts';
+
+import { useWorkspaceStore } from 'src/stores/workspace-store';
+import { useSingleIssueStore } from 'src/stores/single-issue-store';
+import { useNotificationStore } from 'src/stores/notification-store';
+import { useIssuesStatesFlowStore } from 'src/stores/issues-states-flow-store';
+import { useProjectStatesFlowStore } from 'src/stores/project-states-flow-store';
+
+export function useStatusSelect() {
+  const { currentWorkspaceSlug } = storeToRefs(useWorkspaceStore());
+  const singleIssueStore = useSingleIssueStore();
+  const { setNotificationView } = useNotificationStore();
+  const issuesStatesFlowStore = useIssuesStatesFlowStore();
+  const projectStatesFlowStore = useProjectStatesFlowStore();
+
+  const items = ref<DtoStateLight[]>([]);
+  const isLoading = ref(false);
+  const error = ref('');
+
+  const resetItems = () => (items.value = []);
+
+  const loadItems = async (projectId: string, issueId?: string) => {
+    if (items.value.length) return;
+
+    const workspaceSlug = currentWorkspaceSlug.value ?? '';
+
+    isLoading.value = true;
+    error.value = '';
+    try {
+      items.value = issueId
+        ? await issuesStatesFlowStore.getAvailableStates(
+            workspaceSlug,
+            projectId,
+            issueId,
+          )
+        : await projectStatesFlowStore.getAvailableStatesNewIssue(
+            workspaceSlug,
+            projectId,
+          );
+    } catch (e) {
+      error.value = 'Не удалось получить актуальные статусы';
+    } finally {
+      isLoading.value = false;
+    }
+  };
+
+  const updateStatus = async (
+    projectId: string,
+    issueId: string,
+    state: DtoStateLight,
+  ) => {
+    if (!currentWorkspaceSlug.value) return;
+
+    await singleIssueStore.updateIssueData(
+      currentWorkspaceSlug.value,
+      projectId,
+      issueId,
+      { state: state.id },
+    );
+
+    resetItems();
+    setNotificationView({ open: true, type: 'success' });
+  };
+
+  return { items, isLoading, error, loadItems, resetItems, updateStatus };
+}

--- a/src/modules/issue-list/components/board-view/BoardCard.vue
+++ b/src/modules/issue-list/components/board-view/BoardCard.vue
@@ -83,24 +83,16 @@
       <SelectStatus
         v-if="contextProps?.columns_to_show?.includes('state')"
         style="width: auto !important"
-        :projectid="card?.project"
-        :issueid="card?.id"
         :status="card?.state_detail"
         :issue="card"
-        :states-from-cache="statesCache[card.project]"
+        :items="items"
+        :loading="isLoading"
+        :error="statesError"
         :isDisabled="
           !rolesStore.hasPermissionByIssue(card, 'change-issue-status')
         "
-        @refresh="
-          (status) => {
-            emits(
-              'updateTable',
-              'state',
-              Object.assign(card, { state_detail: status }),
-              entity,
-            );
-          }
-        "
+        @popup-show="loadItems(card.project, card.id)"
+        @update:status="onUpdateStatus"
       />
 
       <div class="row">
@@ -178,7 +170,6 @@ import { storeToRefs } from 'pinia';
 import { computed, ref } from 'vue';
 import SelectDate from 'src/components/SelectDate.vue';
 import SelectPriority from 'src/components/SelectPriority.vue';
-import { useStatesStore } from 'src/stores/states-store';
 import SelectStatus from 'src/components/SelectStatus.vue';
 import AvatarImage from 'src/components/AvatarImage.vue';
 import aiplan from 'src/utils/aiplan';
@@ -186,9 +177,13 @@ import QuantityChip from 'src/components/QuantityChip.vue';
 import { useIssueContext } from '../../composables/useIssueContext';
 import IssueContextMenu from 'src/shared/components/IssueContextMenu.vue';
 import { useRolesStore } from 'src/stores/roles-store';
+import { useStatusSelect } from 'src/composables/useStatusSelect';
 import { useUserActivityNavigation } from 'src/composables/useUserActivityNavigation';
 import SelectSprints from 'src/components/SelectSprints.vue';
-import { DtoIssue } from '@aisa-it/aiplan-api-ts/src/data-contracts';
+import {
+  DtoIssue,
+  DtoStateLight,
+} from '@aisa-it/aiplan-api-ts/src/data-contracts';
 
 const { user } = storeToRefs(useUserStore());
 
@@ -198,9 +193,23 @@ const props = defineProps<{
   contextType: 'project' | 'sprint';
 }>();
 const rolesStore = useRolesStore();
+const { items, isLoading, error: statesError, loadItems, updateStatus } =
+  useStatusSelect();
 const avatarText = aiplan.UserName;
 
 const { navigateToActivityPage } = useUserActivityNavigation();
+
+const onUpdateStatus = async (state: DtoStateLight) => {
+  if (state.id === props.card?.state_detail?.id) return;
+
+  await updateStatus(props.card.project, props.card.id, state);
+  emits(
+    'updateTable',
+    'state',
+    Object.assign(props.card, { state_detail: state }),
+    props.entity,
+  );
+};
 
 const isParent = computed((): boolean => {
   return !!props.card?.parent && !!props.card?.parent_detail?.sequence_id;
@@ -211,7 +220,6 @@ const emits = defineEmits<{
   openPreview: [DtoIssue];
   openIssue: [number, string];
 }>();
-const { statesCache } = storeToRefs(useStatesStore());
 const { contextProps } = useIssueContext(props.contextType);
 
 const clickCount = ref(0);

--- a/src/modules/issue-list/components/calendar-view/components/event/EventCard.vue
+++ b/src/modules/issue-list/components/calendar-view/components/event/EventCard.vue
@@ -53,15 +53,19 @@
         <div class="col flex rounded-borders">
           <SelectStatus
             class="issue-selector full-w"
-            :projectid="project.id"
-            :issueid="event.issueData.id"
             :issue="event.issueData"
             :status="event.issueData.state_detail"
+            :items="items"
+            :loading="isLoading"
+            :error="statesError"
             :isDisabled="!canChangeStatus"
-            :states-from-cache="statesCache[project.id]"
-            @set-status="(val) => (event.issueData.state_detail = val)"
-            @refresh="handleRefresh"
-            @popup-show="$emit('statusPopupOrEditName', true)"
+            @update:status="onUpdateStatus"
+            @popup-show="
+              () => {
+                loadItems(project.id, event.issueData.id);
+                $emit('statusPopupOrEditName', true);
+              }
+            "
             @popup-hide="$emit('statusPopupOrEditName', false)"
           />
         </div>
@@ -137,8 +141,9 @@ import { useWorkspaceStore } from 'src/stores/workspace-store';
 import { useProjectStore } from 'src/stores/project-store';
 import { useSingleIssueStore } from 'src/stores/single-issue-store';
 import { useNotificationStore } from 'src/stores/notification-store';
-import { useStatesStore } from 'src/stores/states-store';
+import { useStatusSelect } from 'src/composables/useStatusSelect';
 import { useRolesStore } from 'src/stores/roles-store';
+import { DtoStateLight } from '@aisa-it/aiplan-api-ts/src/data-contracts';
 import { storeToRefs } from 'pinia';
 import { useCalendarEventStore } from '../../store/calendar-event-store';
 import { useCalendarStore } from '../../store/calendar-store';
@@ -174,8 +179,18 @@ const { setNotificationView } = useNotificationStore();
 const workspaceStore = useWorkspaceStore();
 const { currentWorkspaceSlug } = storeToRefs(workspaceStore);
 const { project } = storeToRefs(useProjectStore());
-const { statesCache } = storeToRefs(useStatesStore());
 const { hasPermissionByIssue } = useRolesStore();
+
+const { items, isLoading, error: statesError, loadItems, updateStatus } =
+  useStatusSelect();
+
+const onUpdateStatus = async (state: DtoStateLight) => {
+  if (state.id === props.event.issueData.state_detail?.id) return;
+
+  await updateStatus(project.value.id, props.event.issueData.id, state);
+  props.event.issueData.state_detail = state;
+  handleRefresh();
+};
 
 const canChangeStatus = computed(() =>
   hasPermissionByIssue(

--- a/src/modules/issue-list/components/issue-table/StatusColumn.vue
+++ b/src/modules/issue-list/components/issue-table/StatusColumn.vue
@@ -2,37 +2,49 @@
   <q-td :props="rowInfo">
     <div @click.stop>
       <SelectStatus
-        :projectid="rowInfo.row.project"
-        :issueid="rowInfo.row.id"
         :status="rowInfo.row.state_detail"
         :issue="rowInfo.row"
+        :items="items"
+        :loading="isLoading"
+        :error="statesError"
         :isDisabled="
           !rolesStore.hasPermissionByIssue(rowInfo.row, 'change-issue-status')
         "
-        :states-from-cache="statesCache[rowInfo.row.project]"
-        @set-status="(val: any) => emits('refresh', val)"
+        @popup-show="loadItems(rowInfo.row.project, rowInfo.row.id)"
+        @update:status="onUpdateStatus"
       />
     </div>
   </q-td>
 </template>
 
 <script setup lang="ts">
-// core
-import { storeToRefs } from 'pinia';
-
 // stores
 import { useRolesStore } from 'src/stores/roles-store';
-import { useStatesStore } from 'src/stores/states-store';
+
+// composables
+import { useStatusSelect } from 'src/composables/useStatusSelect';
 
 // components
 import SelectStatus from 'src/components/SelectStatus.vue';
-import { DtoIssue } from '@aisa-it/aiplan-api-ts/src/data-contracts';
+import {
+  DtoIssue,
+  DtoStateLight,
+} from '@aisa-it/aiplan-api-ts/src/data-contracts';
 
-defineProps<{
+const props = defineProps<{
   rowInfo: { row: DtoIssue };
 }>();
 
 const emits = defineEmits<{ refresh: [any] }>();
+
 const rolesStore = useRolesStore();
-const { statesCache } = storeToRefs(useStatesStore());
+const { items, isLoading, error: statesError, loadItems, updateStatus } =
+  useStatusSelect();
+
+const onUpdateStatus = async (state: DtoStateLight) => {
+  if (state.id === props.rowInfo.row.state_detail?.id) return;
+
+  await updateStatus(props.rowInfo.row.project, props.rowInfo.row.id, state);
+  emits('refresh', state);
+};
 </script>


### PR DESCRIPTION
Провел рефакторинг, добавился новый useStatusSelect который сильно сократил код в компонентах, добавил лоадер и вывод ошибки в самом селекте, отвязался от statesCache, в затронутых компонентах он больше не используется. Основной SelectStatus.vue стал минималистичным как и работа с ним. Протыкал все моменты багов не нашел, все работает ожидаемо и чисто.

<img width="435" height="361" alt="image" src="https://github.com/user-attachments/assets/bc392989-5fae-45e0-b4ea-a3fc4d3f08a2" />
<img width="222" height="128" alt="image" src="https://github.com/user-attachments/assets/269388cc-34be-402f-be44-e75d28aa2982" />
 