### PR TITLE
fix: починил ссылку на прохождение формы BUGS-1249

### DIFF
--- a/src/utils/copyLinkToClipboard.ts
+++ b/src/utils/copyLinkToClipboard.ts
@@ -25,7 +25,7 @@ export const copyLinkToClipboard = (
       break;
     }
     case 'forms': {
-      link = `${linkBody.workspaceSlug}/forms/${linkBody.formSlug}`;
+      link = `f/${linkBody.workspaceSlug}/${linkBody.formSlug}`;
       break;
     }
   }


### PR DESCRIPTION
Неправильно формировалась ссылка на прохождение формы при копировании ссылки
Поменял "workspaceSlug/forms/formSlug" на "f/workspaceSlug/formSlug"