### PR TITLE
fix: исправлен баг с 413/401 ошибкой при попытке удаления вложения в АИФормах BUGS-1230

### DIFF
--- a/src/components/forms/components/FormAttachment.vue
+++ b/src/components/forms/components/FormAttachment.vue
@@ -143,8 +143,6 @@ const handleDelete = async (id: string) => {
   if (!id || !props.formSlug) return;
 
   try {
-    await formStore.deleteFormAttachment(props.formSlug, id);
-
     if (Array.isArray(props.field.attachments)) {
       props.field.attachments = props.field.attachments.filter(
         (a: any) => a.id !== id,


### PR DESCRIPTION
В АИФормах при удалении вложения отправлялся запрос на удаление.
Но поскольку при загрузке вложения, оно не загружается на сервер, то удалять с сервера тоже нечего.

Убрал вызов API метода на удаления, поскольку отправка вложения происходит только при отправке самой формы.
В самих задачах для вложений используется другой компонент SelectAttachment, его методы удаления этот фикс не затрагивает.