### PR TITLE
fix: порядок секций в раскрытом и свернутом меню синхронизированы FRO-900

### DIFF
--- a/src/components/ExpansionGroup.vue
+++ b/src/components/ExpansionGroup.vue
@@ -205,21 +205,26 @@ const HelpItem = {
   isLocked: true,
 };
 
-const mergedOrder = [...savedOrder.value];
-defaultOrder.forEach((id) => {
-  if (!mergedOrder.includes(id)) {
-    const helpIndex = mergedOrder.indexOf('help');
-    if (helpIndex >= 0) {
-      mergedOrder.splice(helpIndex, 0, id);
-    } else {
-      mergedOrder.push(id);
+const mergedOrder = computed(() => {
+  const merged = [...savedOrder.value];
+  defaultOrder.forEach((id) => {
+    if (!merged.includes(id)) {
+      const helpIndex = merged.indexOf('help');
+      if (helpIndex >= 0) {
+        merged.splice(helpIndex, 0, id);
+      } else {
+        merged.push(id);
+      }
     }
-  }
+  });
+  return merged;
 });
 
-const validOrderSpy = mergedOrder.filter((id) => itemsMap[id]);
+const validOrderSpy = computed(() =>
+  mergedOrder.value.filter((id) => itemsMap[id]),
+);
 const currentOrder = ref<string[]>(
-  validOrderSpy.length ? validOrderSpy : defaultOrder,
+  validOrderSpy.value.length ? validOrderSpy.value : defaultOrder,
 );
 
 const visibleItems = computed(() => {
@@ -231,6 +236,12 @@ const visibleItems = computed(() => {
 const setItemRef = (id: string, el: any) => {
   if (el) itemRefs.value[id] = el;
 };
+
+watch(validOrderSpy, (newValidOrderSpy) => {
+  currentOrder.value = newValidOrderSpy.length
+    ? newValidOrderSpy
+    : defaultOrder;
+});
 
 watch(
   () => visibleItems.value.length,

--- a/src/components/ExpansionGroup.vue
+++ b/src/components/ExpansionGroup.vue
@@ -72,7 +72,6 @@ import { useSortable } from 'src/composables/useSortable';
 import { useExpansionGroupResize } from 'src/composables/useExpansionGroupResize';
 
 //stores
-import { useUtilsStore } from 'src/stores/utils-store';
 import { useRolesStore } from 'src/stores/roles-store';
 import { useWorkspaceStore } from 'src/stores/workspace-store';
 
@@ -83,9 +82,7 @@ import { isDev } from 'src/utils/helpers';
 import NavMenuProjects from './menu/NavMenuProjects.vue';
 import NavMenuForms from './menu/NavMenuForms.vue';
 import NavMenuBottomBarHelpAndSupport from 'components/menu/NavMenuBottomBarHelpAndSupport.vue';
-import NavMenuAIDocs from './menu/NavMenuAIDocs.vue';
 import NavSprints from './menu/NavSprints.vue';
-import NavMenuConferencesDemo from './menu/NavMenuConferencesDemo.vue';
 
 import HomeIcon from './icons/HomeIcon.vue';
 import AIDocIcon from './icons/AIDocIcon.vue';
@@ -95,9 +92,7 @@ const route = useRoute();
 const router = useRouter();
 
 //stores
-const utilsStore = useUtilsStore();
 const workspaceStore = useWorkspaceStore();
-const { isDemo } = storeToRefs(utilsStore);
 const { workspaceInfo, currentWorkspaceSlug } = storeToRefs(workspaceStore);
 
 //composables
@@ -110,18 +105,12 @@ const itemRefs = ref<Record<string, any>>({});
 const isAIDoc = computed(() => route.fullPath.includes('aidoc'));
 
 //consts
-const defaultOrder = [
-  'sprints',
-  'projects',
-  'forms',
-  'favorites',
-  'docs',
-  'jitsi',
-  'conferences',
-  'help',
-];
-const ORDER_KEY = `${route.params.workspace}_menuOrder`;
-const savedOrder = LocalStorage.getItem<string[]>(ORDER_KEY) || [];
+const defaultOrder = ['projects', 'sprints', 'forms'];
+const OLD_ORDER_KEY = `${route.params.workspace}_menuOrder`;
+const ORDER_KEY = computed(() => `${route.params.workspace}_menu`);
+const savedOrder = computed(
+  () => LocalStorage.getItem<string[]>(ORDER_KEY.value) || [],
+);
 
 // sortable integration
 const { initSortable } = useSortable(menuRef, {
@@ -136,12 +125,13 @@ const { initSortable } = useSortable(menuRef, {
   onEnd: async ({ oldIndex, newIndex }) => {
     if (oldIndex == null || newIndex == null || oldIndex === newIndex) return;
 
-    const movedItem = visibleItems.value[oldIndex];
+    const movedItem = visibleItems.value[oldIndex - 1];
+
     if (!movedItem) return;
 
     const visibleListIds = visibleItems.value.map((i) => i.id);
-    visibleListIds.splice(oldIndex, 1);
-    visibleListIds.splice(newIndex, 0, movedItem.id);
+    visibleListIds.splice(oldIndex - 1, 1);
+    visibleListIds.splice(newIndex - 1, 0, movedItem.id);
 
     const newFullOrder: string[] = [];
     let vIndex = 0;
@@ -156,9 +146,10 @@ const { initSortable } = useSortable(menuRef, {
         newFullOrder.push(id);
       }
     }
+
     currentOrder.value = newFullOrder;
 
-    LocalStorage.set(ORDER_KEY, currentOrder.value);
+    LocalStorage.set(ORDER_KEY.value, currentOrder.value);
   },
 });
 
@@ -173,6 +164,11 @@ const itemsMap: Record<
     isLocked?: boolean;
   }
 > = {
+  projects: {
+    id: 'projects',
+    component: markRaw(NavMenuProjects),
+    condition: () => !isAIDoc.value,
+  },
   sprints: {
     id: 'sprints',
     component: markRaw(NavSprints),
@@ -181,34 +177,19 @@ const itemsMap: Record<
       !!currentWorkspaceSlug.value &&
       hasPermissionByWorkspace(workspaceInfo?.value, 'show-sprints-nav'),
   },
-  projects: {
-    id: 'projects',
-    component: markRaw(NavMenuProjects),
-    condition: () => !isAIDoc.value,
-  },
   forms: {
     id: 'forms',
     component: markRaw(NavMenuForms),
-    condition: () => !isAIDoc.value,
+    condition: () =>
+      !isAIDoc.value &&
+      !!currentWorkspaceSlug.value &&
+      hasPermissionByWorkspace(workspaceInfo?.value, 'show-forms-nav'),
   },
-  favorites: {
-    id: 'favorites',
-    component: markRaw(NavMenuAIDocs),
-    props: { filterBy: 'favorites' },
-    listeners: { updateFavoriteState },
-    condition: () => !!(isAIDoc.value && currentWorkspaceSlug.value),
-  },
-  docs: {
-    id: 'docs',
-    component: markRaw(NavMenuAIDocs),
-    props: { filterBy: 'docs' },
-    condition: () => !!(isAIDoc.value && currentWorkspaceSlug.value),
-  },
-  conferences: {
-    id: 'conferences',
-    component: markRaw(NavMenuConferencesDemo),
-    condition: () => isDemo.value,
-  },
+  // conferences: {
+  //   id: 'conferences',
+  //   component: markRaw(NavMenuConferencesDemo),
+  //   condition: () => isDemo.value,
+  // },
 };
 
 const HelpItem = {
@@ -218,7 +199,7 @@ const HelpItem = {
   isLocked: true,
 };
 
-const mergedOrder = [...savedOrder];
+const mergedOrder = [...savedOrder.value];
 defaultOrder.forEach((id) => {
   if (!mergedOrder.includes(id)) {
     const helpIndex = mergedOrder.indexOf('help');
@@ -245,12 +226,6 @@ const setItemRef = (id: string, el: any) => {
   if (el) itemRefs.value[id] = el;
 };
 
-function updateFavoriteState(id: string, state: boolean) {
-  if (itemRefs.value['docs']) {
-    itemRefs.value['docs'].setFavoriteState(id, state);
-  }
-}
-
 watch(
   () => visibleItems.value.length,
   async () => {
@@ -261,6 +236,9 @@ watch(
 
 onMounted(async () => {
   await initSortable();
+
+  // очистка старого порядка меню у старых пользователей 30.06.26, можно убрать когда пройдет некоторое время
+  LocalStorage.removeItem(OLD_ORDER_KEY);
 });
 
 const fixedHeightItems = ['help', 'jitsi'];

--- a/src/components/drawers/NavBar.vue
+++ b/src/components/drawers/NavBar.vue
@@ -32,7 +32,7 @@
             <q-item-section> Главная </q-item-section>
           </q-item>
 
-          <q-item :active="route.name === 'projects'" clickable v-ripple>
+          <!-- <q-item :active="route.name === 'projects'" clickable v-ripple>
             <q-item-section avatar>
               <MenuProjectsIcon
                 :color="
@@ -49,6 +49,7 @@
 
             <NavPopupProjects />
           </q-item>
+
           <q-item
             v-if="workspaceInfo && hasPermissionByWorkspace(workspaceInfo, 'show-sprints-nav')"
             :active="route.name === 'sprints'"
@@ -58,7 +59,7 @@
             <q-item-section avatar>
               <SprintIcon
                 :color="
-                  route.path.includes('/sprints') ? ACTIVE_ICON_COLOR : ''
+                  route.path.includes('sprints') ? ACTIVE_ICON_COLOR : ''
                 "
               />
             </q-item-section>
@@ -74,13 +75,13 @@
 
           <q-item
             v-if="workspaceInfo && hasPermissionByWorkspace(workspaceInfo, 'show-forms-nav')"
-            :active="route.path.includes('/forms')"
+            :active="route.path === 'forms'"
             clickable
             v-ripple
           >
             <q-item-section avatar>
               <MenuFormsIcon
-                :color="route.path.includes('/forms') ? ACTIVE_ICON_COLOR : ''"
+                :color="route.path.includes('forms') ? ACTIVE_ICON_COLOR : ''"
               />
             </q-item-section>
 
@@ -91,6 +92,29 @@
             </q-item-section>
 
             <NavPopupForms />
+          </q-item> -->
+
+          <q-item
+            v-for="item in orderedItems"
+            :key="item.id"
+            :active="route.path === item.id"
+            clickable
+            v-ripple
+          >
+            <q-item-section avatar>
+              <component
+                :is="item.icon"
+                :color="route.path.includes(item.id) ? ACTIVE_ICON_COLOR : ''"
+              />
+            </q-item-section>
+
+            <q-item-section> {{ item.name }} </q-item-section>
+
+            <q-item-section side>
+              <q-icon name="expand_more" size="16px" />
+            </q-item-section>
+
+            <component :is="item.component" />
           </q-item>
 
           <q-item
@@ -170,8 +194,8 @@
 
 <script setup lang="ts">
 // core
-import { computed, ref, onMounted, watch } from 'vue';
-import { Screen, useQuasar } from 'quasar';
+import { computed, ref, onMounted, watch, markRaw } from 'vue';
+import { LocalStorage, Screen, useQuasar } from 'quasar';
 import { storeToRefs } from 'pinia';
 import { useRoute, useRouter } from 'vue-router';
 
@@ -226,6 +250,48 @@ const isBtnShow = ref(false);
 const ACTIVE_ICON_COLOR = '#3f75ff';
 const DEFAULT_WIDTH = 270;
 
+const defaultOrder = ['projects', 'sprints', 'forms'];
+const ORDER_KEY = computed(() => `${route.params.workspace}_menu`);
+const savedOrder = computed(
+  () => LocalStorage.getItem<string[]>(ORDER_KEY.value) || defaultOrder,
+);
+
+type MenuItem = {
+  id: string;
+  component: any;
+  icon: any;
+  name: string;
+  condition: () => boolean;
+};
+
+const itemsMap: Record<string, MenuItem> = {
+  projects: {
+    id: 'projects',
+    component: markRaw(NavPopupProjects),
+    icon: markRaw(MenuProjectsIcon),
+    name: 'Проекты',
+    condition: () => true,
+  },
+  sprints: {
+    id: 'sprints',
+    component: markRaw(NavPopupSprints),
+    icon: markRaw(SprintIcon),
+    name: 'Спринты',
+    condition: () =>
+      !!workspaceInfo.value &&
+      hasPermissionByWorkspace(workspaceInfo.value, 'show-sprints-nav'),
+  },
+  forms: {
+    id: 'forms',
+    component: markRaw(NavPopupForms),
+    icon: markRaw(MenuFormsIcon),
+    name: 'Формы',
+    condition: () =>
+      !!workspaceInfo.value &&
+      hasPermissionByWorkspace(workspaceInfo.value, 'show-forms-nav'),
+  },
+};
+
 const clientWidth = ref(document.documentElement.clientWidth);
 const isMobile = computed(() => {
   return $q.platform.is.mobile && Screen.lt.md;
@@ -254,6 +320,21 @@ const onSuccess = (msg?: string) => {
 
 const workspaceStore = useWorkspaceStore();
 const { currentWorkspaceSlug, workspaceInfo } = storeToRefs(workspaceStore);
+
+const orderedItems = computed(() => {
+  const sortedItems = savedOrder.value
+    .map((key) => itemsMap[key])
+    .filter((item) => item !== undefined);
+
+  const remainingKeys = Object.keys(itemsMap).filter(
+    (key) => !savedOrder.value.includes(key),
+  );
+  const remainingItems = remainingKeys.map((key) => itemsMap[key]);
+
+  return [...sortedItems, ...remainingItems].filter((el) => {
+    return el.condition();
+  });
+});
 
 onMounted(() => {
   if (currentWorkspaceSlug.value) {


### PR DESCRIPTION
убраны не используемые секции в старом меню
изменен обязательный дефолтный порядок
новый ключ в локал сторадже для меню
зачистка старого ключа для старых пользователей
исправлен колбэк onEnd для назначения порядка в локал сторедж 
ключи и массивы порядков обернуты в компутед, чтобы при смене пространств реактивно обновлялось