### PR TITLE
fix: убрана пустая строка перед вставляемым контентом BUGS-1269

### DIFF
--- a/src/components/editorV2/utils/handleTipTapPaste.ts
+++ b/src/components/editorV2/utils/handleTipTapPaste.ts
@@ -250,9 +250,10 @@ export const handleTipTapPaste = (editorInstance, view, event, slice) => {
   // Сценарий с обычной вставкой
   if (!isInTable || !isSingleTableInHTML(fragment)) {
     event.preventDefault();
+
     const parser = DOMParser.fromSchema(editorInstance.value.schema);
-    const nodes = parser.parse(fragment);
-    dispatch(state.tr.replaceSelectionWith(nodes, false));
+    const slice = parser.parseSlice(fragment);
+    dispatch(state.tr.replaceSelection(slice));
     return true;
   }
 
@@ -261,8 +262,8 @@ export const handleTipTapPaste = (editorInstance, view, event, slice) => {
   if (!pastedTableEl) {
     event.preventDefault();
     const parser = DOMParser.fromSchema(editorInstance.value.schema);
-    const nodes = parser.parse(fragment);
-    dispatch(state.tr.replaceSelectionWith(nodes, false));
+    const slice = parser.parseSlice(fragment);
+    dispatch(state.tr.replaceSelection(slice));
     return true;
   }
 
@@ -284,8 +285,8 @@ export const handleTipTapPaste = (editorInstance, view, event, slice) => {
   // Если таблица не нашлась - обычная вставка
   if (tableDepth === -1) {
     const parser = DOMParser.fromSchema(schema);
-    const nodes = parser.parse(fragment);
-    dispatch(state.tr.replaceSelectionWith(nodes, false));
+    const slice = parser.parseSlice(fragment);
+    dispatch(state.tr.replaceSelection(slice));
     return true;
   }
 


### PR DESCRIPTION
Пользователь ставит курсор в редактор, куда собирается осуществить вставку, на этом месте создается пустой параграф, а когда осуществляет вставку, элемент вставляется после этого пустого параграфа

Происходит это из-за того, что replaceSelectionWith вставляет корневой документ, вместо этого использовал parseSlice + replaceSelection, чтобы корректно заменить текущее выделение