### PR TITLE
fix: предотвращен переход на страницу с ошибкой 404 при быстрой навигации в левом меню BUGS-1276

### DIFF
--- a/src/components/forms/pages/FormsTable.vue
+++ b/src/components/forms/pages/FormsTable.vue
@@ -135,6 +135,8 @@ const openAnswers = (answer) => {
 };
 
 const refresh = async (props) => {
+  if (!route.params.workspace || !route.params.formSlug) return;
+
   const { page, rowsPerPage, sortBy, descending } = props.pagination;
 
   const offset = (page - 1) * (rowsPerPage == 0 ? 10 : rowsPerPage);

--- a/src/components/forms/services/api.ts
+++ b/src/components/forms/services/api.ts
@@ -69,6 +69,7 @@ export const getAnswers = async (
   formSlug: string,
   query?: { offset?: number; limit?: number },
 ) => {
+  if (!workspaceSlug || !formSlug) return;
   return (await api.getAnswers(workspaceSlug, formSlug, query)).data;
 };
 

--- a/src/modules/issue-list/composables/useIssueContext.ts
+++ b/src/modules/issue-list/composables/useIssueContext.ts
@@ -21,6 +21,8 @@ export function useIssueContext(contextType: 'project' | 'sprint') {
   const issuesStore = useIssuesStore();
   const route = useRoute();
 
+  if (!route.params.workspace) return;
+
   if (contextType === 'project') {
     const store = useProjectStore();
     const { projectProps, isGroupingEnabled, isKanbanEnabled, issuesLoader } =

--- a/src/modules/issue-list/composables/useLoadProjectInfo.ts
+++ b/src/modules/issue-list/composables/useLoadProjectInfo.ts
@@ -10,6 +10,7 @@ export const useLoadProjectInfo = () => {
   const route = useRoute();
 
   const getProjectInfo = async () => {
+    if (!route.params.workspace || !route.params.project) return;
     await projectStore.getProjectInfo(
       route.params.workspace as string,
       route.params.project as string,
@@ -17,6 +18,7 @@ export const useLoadProjectInfo = () => {
   };
 
   const getMeInProject = async () => {
+    if (!route.params.workspace || !route.params.project) return;
     await projectStore.getMeInProject(
       route.params.workspace as string,
       route.params.project as string,
@@ -24,6 +26,7 @@ export const useLoadProjectInfo = () => {
   };
 
   const getStatuses = async () => {
+    if (!route.params.workspace || !route.params.project) return;
     await projectStore.getProjectStatuses(
       route.params.workspace as string,
       route.params.project as string,
@@ -31,6 +34,7 @@ export const useLoadProjectInfo = () => {
   };
 
   const getLabels = async () => {
+    if (!route.params.workspace || !route.params.project) return;
     await projectStore.getProjectLabels(
       route.params.workspace as string,
       route.params.project as string,
@@ -38,6 +42,7 @@ export const useLoadProjectInfo = () => {
   };
 
   const getMembers = async () => {
+    if (!route.params.workspace || !route.params.project) return;
     await projectStore.getProjectMembers(
       route.params.workspace as string,
       route.params.project as string,

--- a/src/modules/sprints/stores/sprint-store.ts
+++ b/src/modules/sprints/stores/sprint-store.ts
@@ -180,7 +180,6 @@ export const useSprintStore = defineStore('sprint-store', {
       query?: IQuery,
       signal?: AbortSignal,
     ) {
-      if (!this.sprint) return;
       return api.post(
         `/api/auth/workspaces/${wsSlug}/sprints/${sprintSlug}/issues/search/`,
         { ...filters },

--- a/src/modules/sprints/stores/sprint-store.ts
+++ b/src/modules/sprints/stores/sprint-store.ts
@@ -180,6 +180,7 @@ export const useSprintStore = defineStore('sprint-store', {
       query?: IQuery,
       signal?: AbortSignal,
     ) {
+      if (!this.sprint) return;
       return api.post(
         `/api/auth/workspaces/${wsSlug}/sprints/${sprintSlug}/issues/search/`,
         { ...filters },

--- a/src/pages/SprintPage.vue
+++ b/src/pages/SprintPage.vue
@@ -113,6 +113,7 @@ const load = async (signal?: AbortSignal) => {
 };
 
 const updateSprint = async () => {
+  if (!router.currentRoute.value.params.workspace || !router.currentRoute.value.params.sprint) return;
   sprintLoader.value = true;
   issuesLoader.value = true;
   sprint.value = await getSprint(

--- a/src/stores/issues-store.ts
+++ b/src/stores/issues-store.ts
@@ -146,6 +146,7 @@ export const useIssuesStore = defineStore('issues-store', {
       query: IQuery,
       signal?: AbortSignal,
     ) {
+      if (!workspaceSlug || !projectId) return;
       try {
         const response = await api.post(
           `${API_WORKSPACES_PREFIX}/${workspaceSlug}/projects/${projectId}/issues/search`,


### PR DESCRIPTION
Добавлены fallback-выражения для предотвращения отправки запросов с некорректными данными в route.
Переход на 404 страницу происходил из-за отсутствия данных для запроса и загрузки информации, что вызывало редирект.