### PR TITLE
fix: убраны лишние пробелы при копировании из ворда BUGS-1269

### DIFF
--- a/src/components/editorV2/utils/handleTipTapPaste.ts
+++ b/src/components/editorV2/utils/handleTipTapPaste.ts
@@ -255,7 +255,14 @@ export const handleTipTapPaste = (editorInstance, view, event, slice) => {
     event.preventDefault();
 
     const parser = DOMParser.fromSchema(editorInstance.value.schema);
-    const slice = parser.parseSlice(fragment);
+
+    fragment.querySelectorAll('br.Apple-interchange-newline').forEach((el) => {
+      el.remove();
+    });
+
+    const doc = parser.parse(fragment);
+
+    const slice = doc.slice(0, doc.content.size);
 
     if (isEmptyParagraph) {
       const from = $from.before();


### PR DESCRIPTION
2 лишних пробела в конце появляются у юзеров на мак ос, из-за добавления служебного тэга с Apple-interchange-newline
вычищаю его перед парсингом, не влияет на переносы в самом пришедшем html
Еще был баг с тем, что иногда при копировании из ворда могла появится пустая строка в случайном месте текста, связано это с особенностями parseSlice, заменил его на doc.slice