### PR TITLE
fix: синхронизания спринтов в раскрытом и свернутом менею BUGS-1272

### DIFF
--- a/src/components/menu/NavSprints.vue
+++ b/src/components/menu/NavSprints.vue
@@ -124,9 +124,12 @@ const { setNotificationView } = useNotificationStore();
 const { hasPermission } = useRolesStore();
 
 const { workspaceInfo, currentWorkspaceSlug } = storeToRefs(workspaceStore);
+const { sprintsList } = storeToRefs(sprintStore);
 
 const route = useRoute();
-const sprints = ref([] as DtoSprintLight[]);
+const sprints = computed(
+  () => sprintsList.value?.map((folder) => folder?.sprints || []).flat() ?? [],
+);
 
 const openCreateSprint = ref(false);
 const openEditSprint = ref(false);
@@ -136,17 +139,8 @@ const isDeleteDialogOpen = ref(false);
 const openSprintNotifications = ref(false);
 const canCreateSprint = computed(() => hasPermission('create-sprint'));
 
-onMounted(async () => {
-  sprints.value =
-    workspaceStore.workspaceSummary?.sprints
-      ?.map((folder) => folder?.sprints || [])
-      .flat() ?? [];
-});
-
 const refreshSprints = async () => {
   await sprintStore.getSprintsList(currentWorkspaceSlug.value ?? '');
-  sprints.value =
-    sprintStore.sprintsList.map((folder) => folder.sprints || []).flat() ?? [];
 };
 
 const reopen = async (id: string) => {
@@ -215,9 +209,10 @@ const headerMenuItems = computed(() => [
 
 watch(
   () => workspaceStore.workspaceSummary?.sprints,
-  (newVal) => {
-    sprints.value = newVal?.map((folder) => folder?.sprints || []).flat() ?? [];
+  (newSprintList) => {
+    sprintsList.value = newSprintList ?? [];
   },
+  { immediate: true },
 );
 
 watch(currentWorkspaceSlug, async (newValue) => {

--- a/src/components/nav-popups/NavPopupSprints.vue
+++ b/src/components/nav-popups/NavPopupSprints.vue
@@ -58,9 +58,11 @@
 
 <script setup lang="ts">
 // core
-import { computed } from 'vue';
+import { computed, watch, ref } from 'vue';
 import { storeToRefs } from 'pinia';
 import { useRoute } from 'vue-router';
+
+import { useSprintStore } from 'src/modules/sprints/stores/sprint-store';
 
 // stores
 import { useWorkspaceStore } from 'src/stores/workspace-store';
@@ -73,10 +75,22 @@ const workspaceStore = useWorkspaceStore();
 const { currentWorkspaceSlug } = storeToRefs(workspaceStore);
 const route = useRoute();
 
-const sprints = computed(() => workspaceStore.workspaceSummary?.sprints ?? []);
+const { sprintsList } = storeToRefs(useSprintStore());
+
+const sprints = computed(
+  () => sprintsList.value?.map((folder) => folder?.sprints || []).flat() ?? [],
+);
 
 const formatSprintDates = (start?: string, end?: string): string => {
   if (!start || !end) return '';
   return `${renderShortDate(start)?.toLowerCase()} — ${renderShortDate(end)?.toLowerCase()}`;
 };
+
+watch(
+  () => workspaceStore.workspaceSummary?.sprints,
+  (newSprintList) => {
+    sprintsList.value = newSprintList ?? [];
+  },
+  { immediate: true },
+);
 </script>


### PR DESCRIPTION
Добавлено раскрытие папок из summary в свернутое боковое меню
чтобы была полная синхронизация между свернутым и развернутым меню массив спринтов сделан и там и там через computed свойство, которое ориентируется на список спринтов из стора спринтов
При summary запросе массив спринтов отправляется в стор спринтов, чтобы добиться единой точки истины