### PR TITLE
fix: исправление вставки текста из гугл дока BUGS-1269

### DIFF
--- a/src/components/editorV2/utils/handleTipTapPaste.ts
+++ b/src/components/editorV2/utils/handleTipTapPaste.ts
@@ -250,6 +250,22 @@ export const handleTipTapPaste = (editorInstance, view, event, slice) => {
   const isEmptyParagraph =
     $from.parent.type.name === 'paragraph' && $from.parent.content.size === 0;
 
+  function replaceBrWithMsoParagraph(fragment: DocumentFragment) {
+    const brs = Array.from(fragment.querySelectorAll('br'));
+
+    for (const br of brs) {
+      const p = document.createElement('p');
+      p.className = 'MsoNormal';
+
+      const o = document.createElement('o:p');
+      o.innerHTML = '&nbsp;';
+
+      p.appendChild(o);
+
+      br.replaceWith(p);
+    }
+  }
+
   // Сценарий с обычной вставкой
   if (!isInTable || !isSingleTableInHTML(fragment)) {
     event.preventDefault();
@@ -259,6 +275,8 @@ export const handleTipTapPaste = (editorInstance, view, event, slice) => {
     fragment.querySelectorAll('br.Apple-interchange-newline').forEach((el) => {
       el.remove();
     });
+
+    if (/docs-internal-guid/i.test(html)) replaceBrWithMsoParagraph(fragment);
 
     const doc = parser.parse(fragment);
 

--- a/src/components/editorV2/utils/handleTipTapPaste.ts
+++ b/src/components/editorV2/utils/handleTipTapPaste.ts
@@ -255,7 +255,14 @@ export const handleTipTapPaste = (editorInstance, view, event, slice) => {
     event.preventDefault();
 
     const parser = DOMParser.fromSchema(editorInstance.value.schema);
-    const slice = parser.parseSlice(fragment);
+
+    fragment.querySelectorAll('br.Apple-interchange-newline').forEach((el) => {
+      el.remove();
+    });
+
+    const doc = parser.parse(fragment);
+
+    const slice = doc.slice(0, doc.content.size);
 
     if (isEmptyParagraph) {
       const from = $from.before();


### PR DESCRIPTION
Гугл док на месте пустых строк ставит <br>, что в PropsMirror превращается в hardBreak, который превращается в двойной <br> в редакторе
Для кейса с гугл доком меняю пришедшие <br> на вордовский формат <p class="MsoNormal"><o:p>&nbsp;</o:p></p>