### PR TITLE
fix: убраны успешные уведомления на странице и превью задачи FRO-901

### DIFF
--- a/src/components/NewIssueDialog.vue
+++ b/src/components/NewIssueDialog.vue
@@ -4,6 +4,7 @@
       v-if="workspaceProjects"
       :project_detail="project"
       :parentissue="parent"
+      :off-success-notification="offSuccessNotification"
       class="q-dialog-plugin"
       style="min-width: 80vw"
       @ok="
@@ -54,7 +55,11 @@ import ConfirmLostEditionDialog from './ConfirmLostEditionDialog.vue';
 //types
 import { DtoProject } from '@aisa-it/aiplan-api-ts/src/data-contracts';
 
-const props = defineProps<{ parent?: string; project?: DtoProject }>();
+const props = defineProps<{
+  parent?: string;
+  project?: DtoProject;
+  offSuccessNotification?: boolean;
+}>();
 const emits = defineEmits([
   ...useDialogPluginComponent.emits,
   'update',

--- a/src/components/NewIssuePanel.vue
+++ b/src/components/NewIssuePanel.vue
@@ -352,6 +352,7 @@ const props = defineProps<{
   isUserTextData?: boolean;
   isIssuesTemplate?: boolean;
   loading?: boolean;
+  offSuccessNotification?: boolean;
 }>();
 
 const emits = defineEmits<{
@@ -382,8 +383,13 @@ const singleIssueStore = useSingleIssueStore();
 const sprintStore = useSprintStore();
 const { setNotificationView } = useNotificationStore();
 const { hasPermissionByWorkspace, getProjectRole } = useRolesStore();
-const { items, isLoading, error: statesError, loadItems, resetItems } =
-  useStatusSelect();
+const {
+  items,
+  isLoading,
+  error: statesError,
+  loadItems,
+  resetItems,
+} = useStatusSelect();
 
 //storesToRefs
 const { currentWorkspaceSlug, workspaceInfo } = storeToRefs(workspaceStore);
@@ -618,16 +624,18 @@ const handleCreateSuccess = async (createdIssueData: any) => {
     issue.sequence_id || createdIssueData.id,
   );
 
-  setNotificationView({
-    open: true,
-    type: 'success',
-    customMessage: props.parentissue
-      ? getSuccessCreateSubissueMessage(link)
-      : getSuccessCreateIssueMessage(
-          link,
-          `${issue.project_detail.identifier}-${issue.sequence_id || 0}`,
-        ),
-  });
+  if (!props.offSuccessNotification) {
+    setNotificationView({
+      open: true,
+      type: 'success',
+      customMessage: props.parentissue
+        ? getSuccessCreateSubissueMessage(link)
+        : getSuccessCreateIssueMessage(
+            link,
+            `${issue.project_detail.identifier}-${issue.sequence_id || 0}`,
+          ),
+    });
+  }
 
   await selectAttachments.value.uploadDraftAttachments(createdIssueData.id);
 

--- a/src/components/SelectAttachments.vue
+++ b/src/components/SelectAttachments.vue
@@ -120,6 +120,7 @@
               :key="attachment.id"
               :isEdit="isEdit"
               :file="attachment"
+              :off-success-notification="offSuccessNotification"
               class="inline-block"
               @copy-link="handleCopyLinkFile"
               @open="
@@ -143,6 +144,7 @@
                 created_at: new Date().toISOString(),
                 id: file.id || '',
               }"
+              :off-success-notification="offSuccessNotification"
               class="inline-block"
               @cancel="cancelUpload(file.name)"
               @delete="
@@ -183,6 +185,7 @@
       :attachments="attachments"
       :loading="loading"
       :download-all-func="downloadAllFunc"
+      :off-success-notification="offSuccessNotification"
       @open="
         (val) => {
           openDoc = true;
@@ -266,6 +269,7 @@ const props = defineProps<{
   downloadAllFunc?: () => Promise<{ url: string; fileName: string }>;
   issueData?: DtoIssue;
   draftMode?: boolean;
+  offSuccessNotification?: boolean;
 }>();
 
 const uploader = useTusUploader({
@@ -283,6 +287,7 @@ const uploader = useTusUploader({
       } `,
     });
   },
+  offSuccessNotification: props.offSuccessNotification,
 });
 
 //core
@@ -370,6 +375,7 @@ const uploadDraftAttachments = async (entityId: string) => {
         } `,
       });
     },
+    offSuccessNotification: props.offSuccessNotification,
   });
   for (const draft of draftFiles.value) {
     uploader.enqueue(draft.file);
@@ -552,11 +558,13 @@ const handleDelete = async () => {
   try {
     if (!props.deleteAttachmentFunc) return;
     await props.deleteAttachmentFunc(currentAttachmentDelete.value.id);
-    setNotificationView({
-      open: true,
-      type: 'success',
-      customMessage: SUCCESS_DELETE_ATTACHMENT,
-    });
+    if (!props.offSuccessNotification) {
+      setNotificationView({
+        open: true,
+        type: 'success',
+        customMessage: SUCCESS_DELETE_ATTACHMENT,
+      });
+    }
   } catch (error) {
     setNotificationView({
       open: true,
@@ -580,11 +588,13 @@ const handleDownload = async () => {
       a.click();
       document.body.removeChild(a);
       URL.revokeObjectURL(url);
-      setNotificationView({
-        type: 'success',
-        open: true,
-        customMessage: SUCCESS_DOWNLOAD_FILE,
-      });
+      if (!props.offSuccessNotification) {
+        setNotificationView({
+          type: 'success',
+          open: true,
+          customMessage: SUCCESS_DOWNLOAD_FILE,
+        });
+      }
     }
   } finally {
     loading.value = false;
@@ -597,16 +607,20 @@ const handleCopyLinkFile = (file: IAttachmentCard) => {
       window.location.origin,
       route.path.includes('aidoc') ? 'aidoc' : 'issue',
       route.params.workspace as string,
-      route.path.includes('aidoc') ? (route.params.doc as string) : `${issueData.value?.project_detail?.identifier}-${issueData.value?.sequence_id}`,
+      route.path.includes('aidoc')
+        ? (route.params.doc as string)
+        : `${issueData.value?.project_detail?.identifier}-${issueData.value?.sequence_id}`,
       file.asset?.name,
       file.asset.id,
     );
     copyToClipboard(link);
-    setNotificationView({
-      type: 'success',
-      open: true,
-      customMessage: SUCCESS_COPY_LINK_TO_CLIPBOARD,
-    });
+    if (!props.offSuccessNotification) {
+      setNotificationView({
+        type: 'success',
+        open: true,
+        customMessage: SUCCESS_COPY_LINK_TO_CLIPBOARD,
+      });
+    }
   } catch (e) {
     setNotificationView({
       type: 'error',

--- a/src/components/SelectBlockIssues.vue
+++ b/src/components/SelectBlockIssues.vue
@@ -66,6 +66,7 @@ const props = withDefaults(
     issues?: any[];
     target?: string;
     isDisabled?: boolean;
+    offSuccessNotification?: boolean;
   }>(),
   {
     issues: () => [],
@@ -98,7 +99,9 @@ const saveBlockIssues = async (items) => {
   api
     .issuePartialUpdate(props.workspaceId, props.projectid, props.issueid, data)
     .then(() => {
-      setNotificationView({ type: 'success', open: true });
+      if (!props.offSuccessNotification) {
+        setNotificationView({ type: 'success', open: true });
+      }
       emits('refresh', items);
     });
 };
@@ -117,7 +120,9 @@ const updateModelValue = (val: any) => {
   api
     .issuePartialUpdate(props.workspaceId, props.projectid, props.issueid, data)
     .then(() => {
-      setNotificationView({ type: 'success', open: true });
+      if (!props.offSuccessNotification) {
+        setNotificationView({ type: 'success', open: true });
+      }
       emits('refresh', ids);
       delete listDisableIssue.value[val[nameDetail.value].id];
     })

--- a/src/components/SelectBlockedIssues.vue
+++ b/src/components/SelectBlockedIssues.vue
@@ -68,6 +68,7 @@ const props = withDefaults(
     issues?: any[];
     target?: string;
     isDisabled?: boolean;
+    offSuccessNotification?: boolean;
   }>(),
   {
     issues: () => [],
@@ -99,7 +100,9 @@ const saveBlockIssues = async (items) => {
   api
     .issuePartialUpdate(props.workspaceId, props.projectid, props.issueid, data)
     .then(() => {
-      setNotificationView({ type: 'success', open: true });
+      if (!props.offSuccessNotification) {
+        setNotificationView({ type: 'success', open: true });
+      }
       emits('refresh');
     });
 };
@@ -118,7 +121,9 @@ const updateModelValue = (val: any) => {
   api
     .issuePartialUpdate(props.workspaceId, props.projectid, props.issueid, data)
     .then(() => {
-      setNotificationView({ type: 'success', open: true });
+      if (!props.offSuccessNotification) {
+        setNotificationView({ type: 'success', open: true });
+      }
       emits('refresh');
       delete listDisableIssue.value[val[nameDetail.value].id];
     })

--- a/src/components/SelectDate.vue
+++ b/src/components/SelectDate.vue
@@ -155,6 +155,7 @@ const props = withDefaults(
     maxYearMonth?: string;
     placeholder?: string;
     type?: 'kanban' | 'table' | 'issue';
+    offSuccessNotification?: boolean;
   }>(),
   {
     minYearMonth: `${dayjs(new Date()).year()}/01`,
@@ -269,7 +270,8 @@ function save(notify: boolean = false): void {
         target_date: targetDateValue,
       })
       .then(() => {
-        if (notify) setNotificationView({ type: 'success', open: true });
+        if (notify && !props.offSuccessNotification)
+          setNotificationView({ type: 'success', open: true });
         emits('refresh', proxyDate.value);
       });
   } else {

--- a/src/components/SelectParentIssue.vue
+++ b/src/components/SelectParentIssue.vue
@@ -58,6 +58,7 @@ const props = defineProps<{
   project: IProject;
   isDisabled?: boolean;
   newIssue?: boolean;
+  offSuccessNotification?: boolean;
 }>();
 
 const emits = defineEmits<{
@@ -94,7 +95,10 @@ const saveParentIssue = (issue: any, extendedIssue?: any) => {
         },
       )
       .then(() => {
-        setNotificationView({ type: 'success', open: true });
+        if (!props.offSuccessNotification) {
+          setNotificationView({ type: 'success', open: true });
+        }
+
         emits('refresh', issue);
         onLoad();
       });

--- a/src/components/SelectPriority.vue
+++ b/src/components/SelectPriority.vue
@@ -63,6 +63,7 @@ const props = defineProps<{
   editIssue?: boolean;
   isDisabled?: boolean;
   isAdaptiveSelect?: boolean;
+  offSuccessNotification?: boolean;
 }>();
 
 const emits = defineEmits<{
@@ -80,7 +81,9 @@ const handleUpdateModelValue = (e: string) => {
         priority: e,
       })
       .then(() => {
-        setNotificationView({ type: 'success', open: true });
+        if (!props.offSuccessNotification) {
+          setNotificationView({ open: true, type: 'success' });
+        }
         emits('refresh');
         emits('update:priority', e);
       });

--- a/src/components/SelectSprints.vue
+++ b/src/components/SelectSprints.vue
@@ -54,6 +54,7 @@
   <ManageIssueSprintsDialog
     v-model="isDialogOpen"
     :issue="issue"
+    :off-success-notification="offSuccessNotification"
     :checked-sprints="currentSprints"
     @refresh="emits('refresh')"
     @hide="() => selectSprintRef.hidePopup()"
@@ -100,6 +101,7 @@ const props = withDefaults(
     isAdaptiveSelect?: boolean;
     hideDropdownIcon?: boolean;
     isLoading?: boolean;
+    offSuccessNotification?: boolean;
   }>(),
   {
     isDisabled: () => false,
@@ -172,7 +174,9 @@ const handleUpdateSprints = async (
       sprintStore.triggerSprintRefresh();
     }
 
-    setNotificationView({ open: true, type: 'success' });
+    if (!props.offSuccessNotification) {
+      setNotificationView({ type: 'success', open: true });
+    }
     emits('refresh');
   }
 };

--- a/src/components/dialogs/AttachmentsListDialog.vue
+++ b/src/components/dialogs/AttachmentsListDialog.vue
@@ -213,6 +213,7 @@ const props = defineProps<{
   attachments: IAttachmentCard[];
   loading: boolean;
   downloadAllFunc?: () => Promise<{ url: string; fileName: string }>;
+  offSuccessNotification?: boolean;
 }>();
 
 const emits = defineEmits<{
@@ -279,11 +280,13 @@ const handleCopyLink = (file: IAttachmentCard): void => {
     const query = `?slug=${slug}&type=${type}&from=${from}&name=${name}`;
     const link = base + query;
     copyToClipboard(link);
-    setNotificationView({
-      type: 'success',
-      open: true,
-      customMessage: SUCCESS_COPY_LINK_TO_CLIPBOARD,
-    });
+    if (!props.offSuccessNotification) {
+      setNotificationView({
+        type: 'success',
+        open: true,
+        customMessage: SUCCESS_COPY_LINK_TO_CLIPBOARD,
+      });
+    }
   } catch (e) {
     setNotificationView({
       type: 'error',
@@ -313,11 +316,13 @@ const handleDownload = async (file: IAttachmentCard): Promise<void> => {
     a.click();
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
-    setNotificationView({
-      type: 'success',
-      open: true,
-      customMessage: SUCCESS_DOWNLOAD_FILE,
-    });
+    if (!props.offSuccessNotification) {
+      setNotificationView({
+        type: 'success',
+        open: true,
+        customMessage: SUCCESS_DOWNLOAD_FILE,
+      });
+    }
   } finally {
     downloadProgress.value = 0;
   }
@@ -333,11 +338,13 @@ const handleDownloadAll = async (): Promise<void> => {
     a.click();
     document.body.removeChild(a);
     URL.revokeObjectURL(url);
-    setNotificationView({
-      type: 'success',
-      open: true,
-      customMessage: SUCCESS_DOWNLOAD_FILE,
-    });
+    if (!props.offSuccessNotification) {
+      setNotificationView({
+        type: 'success',
+        open: true,
+        customMessage: SUCCESS_DOWNLOAD_FILE,
+      });
+    }
   }
 };
 </script>

--- a/src/components/dialogs/IssueDialogs/ManageIssueSprintsDialog.vue
+++ b/src/components/dialogs/IssueDialogs/ManageIssueSprintsDialog.vue
@@ -114,6 +114,7 @@ import { ROOT_FOLDER_ID } from 'src/constants/constants';
 const props = defineProps<{
   issue: any;
   checkedSprints?: DtoSprintLight[];
+  offSuccessNotification?: boolean;
 }>();
 
 const emits = defineEmits<{
@@ -221,11 +222,13 @@ const saveIssueSprints = async () => {
     ];
     await Promise.all(updatePromises);
     emits('refresh');
-    setNotificationView({
-      open: true,
-      type: 'success',
-      customMessage: SUCCESS_UPDATE_DATA,
-    });
+    if (!props.offSuccessNotification) {
+      setNotificationView({
+        open: true,
+        type: 'success',
+        customMessage: SUCCESS_UPDATE_DATA,
+      });
+    }
   } catch {}
 };
 

--- a/src/components/issue-panels/SingleIssueActivityComments.vue
+++ b/src/components/issue-panels/SingleIssueActivityComments.vue
@@ -341,11 +341,6 @@ const createComment = async () => {
 function onSuccess() {
   refresh();
   clearEditor();
-  setNotificationView({
-    open: true,
-    type: 'success',
-    customMessage: SUCCESS_COMMENT_CREATING,
-  });
 
   isVisibleEditor.value = false;
   isSendComment.value = false;

--- a/src/components/issue-panels/SingleIssueActivityCommentsList.vue
+++ b/src/components/issue-panels/SingleIssueActivityCommentsList.vue
@@ -132,14 +132,7 @@ const handleUpdateComment = async (data: IIssueCommentUpdate) => {
       data.text,
       issueComment.value.reply_to_comment_id,
     )
-    .then(() => emits('refresh'))
-    .then(() =>
-      setNotificationView({
-        type: 'success',
-        open: true,
-        customMessage: SUCCESS_COMMENT_EDITING,
-      }),
-    );
+    .then(() => emits('refresh'));
 };
 
 const handleDeleteComment = async () => {
@@ -150,14 +143,7 @@ const handleDeleteComment = async () => {
     )
     .then(() => {
       emits('refresh');
-    })
-    .then(() =>
-      setNotificationView({
-        type: 'success',
-        open: true,
-        customMessage: SUCCESS_COMMENT_DELETING,
-      }),
-    );
+    });
 };
 
 const handleAddReaction = async (

--- a/src/components/issue-panels/SingleIssueDrawer.vue
+++ b/src/components/issue-panels/SingleIssueDrawer.vue
@@ -95,6 +95,7 @@
             :isDisabled="!hasPermissionByIssue(issueData, 'change-issue-basic')"
             :current-member="user"
             debounced
+            off-success-notification
             @refresh="handleRefresh"
           ></SelectAssignee>
         </div>
@@ -119,6 +120,7 @@
             :current-member="user"
             :isDisabled="!hasPermissionByIssue(issueData, 'change-issue-basic')"
             debounced
+            off-success-notification
             @refresh="handleRefresh"
           ></SelectWatchers>
         </div>
@@ -141,6 +143,7 @@
             :workspace-slug="issueData.workspace_detail.slug"
             :projectid="issueData.project"
             editIssue
+            off-success-notification
             :issueid="issueData.id"
             :priority="issueData.priority"
             :issue="issueData"
@@ -196,6 +199,7 @@
         <div class="col flex rounded-borders">
           <SelectDate
             class="full-w"
+            off-success-notification
             :workspace-id="issueData.workspace_detail.slug"
             :project-id="issueData.project"
             :issue-id="issueData.id"
@@ -261,6 +265,7 @@
         <div class="col flex rounded-borders no-wrap">
           <SelectParentIssue
             class="full-w"
+            off-success-notification
             :projectid="issueData.project"
             :issueid="issueData.id"
             :issue="issueData.parent_detail"
@@ -295,6 +300,7 @@
         </div>
         <div class="col flex rounded-borders column">
           <SelectBlockIssues
+            off-success-notification
             :workspace-id="issueData.workspace"
             :projectid="issueData.project"
             :issueid="issueData.id"
@@ -320,6 +326,7 @@
         </div>
         <div class="col flex rounded-borders column">
           <SelectBlockedIssues
+            off-success-notification
             :workspace-id="issueData.workspace"
             :projectid="issueData.project"
             :issueid="issueData.id"
@@ -345,6 +352,7 @@
         </div>
         <div class="col flex rounded-borders column">
           <SelectSprints
+            off-success-notification
             :projectid="issueData.project"
             class="issue-selector"
             :issue="issueData"
@@ -375,6 +383,7 @@
       </SelectLinks>
 
       <IssueCustomProperties
+        off-success-notification
         class="q-pt-md"
         :project-id="issueData.project"
         :issue-id="issueData.id"
@@ -423,7 +432,6 @@ import { useRolesStore } from 'src/stores/roles-store';
 import { useProjectStore } from 'src/stores/project-store';
 import { useWorkspaceStore } from 'src/stores/workspace-store';
 import { useSingleIssueStore } from 'src/stores/single-issue-store';
-import { useNotificationStore } from 'src/stores/notification-store';
 
 // utils
 import aiplan from 'src/utils/aiplan';
@@ -465,14 +473,6 @@ import StartDateIcon from 'src/components/icons/StartDateIcon.vue';
 import EndDateIcon from 'src/components/icons/EndDateIcon.vue';
 import SprintIcon from '../icons/SprintIcon.vue';
 
-// constants
-import {
-  SUCCESS_UPDATE_DATA,
-  SUCCESS_LINK_ADDING,
-  SUCCESS_LINK_EDITING,
-  SUCCESS_LINK_DELETING,
-} from 'src/constants/notifications';
-
 import { setIntervalFunction } from 'src/utils/helpers';
 import {
   DtoIssue,
@@ -486,9 +486,13 @@ const projectStore = useProjectStore();
 const { hasPermissionByIssue, hasPermissionByWorkspace } = useRolesStore();
 const workspaceStore = useWorkspaceStore();
 const singleIssueStore = useSingleIssueStore();
-const { setNotificationView } = useNotificationStore();
-const { items, isLoading, error: statesError, loadItems, updateStatus } =
-  useStatusSelect();
+const {
+  items,
+  isLoading,
+  error: statesError,
+  loadItems,
+  updateStatus,
+} = useStatusSelect(true);
 
 // store to refs
 const { user } = storeToRefs(userStore);
@@ -570,11 +574,6 @@ const handleRemoveParentIssue = async () => {
       { parent: null },
     )
     .then(async () => {
-      setNotificationView({
-        type: 'success',
-        open: true,
-        customMessage: SUCCESS_UPDATE_DATA,
-      });
       issueData.value.parent_detail = null;
       handleRefresh();
     });
@@ -631,11 +630,6 @@ const handleLinkAdd = async (link: DtoIssueLinkLight) => {
   );
 
   await handleRefresh();
-  setNotificationView({
-    type: 'success',
-    open: true,
-    customMessage: SUCCESS_LINK_ADDING,
-  });
 };
 
 const handleLinkDelete = async (linkID: string) => {
@@ -648,11 +642,6 @@ const handleLinkDelete = async (linkID: string) => {
   );
 
   await handleRefresh();
-  setNotificationView({
-    type: 'success',
-    open: true,
-    customMessage: SUCCESS_LINK_DELETING,
-  });
 };
 
 const handleLinkEdit = async (link: DtoIssueLinkLight) => {
@@ -667,11 +656,6 @@ const handleLinkEdit = async (link: DtoIssueLinkLight) => {
   );
 
   await handleRefresh();
-  setNotificationView({
-    type: 'success',
-    open: true,
-    customMessage: SUCCESS_LINK_EDITING,
-  });
 };
 
 const updateParentIssueData = async () => {

--- a/src/components/selects/SelectAssignee.vue
+++ b/src/components/selects/SelectAssignee.vue
@@ -137,6 +137,7 @@ const props = withDefaults(
     currentMember: any;
     isIssueTransfer?: boolean;
     debounced?: boolean;
+    offSuccessNotification?: boolean;
   }>(),
   {
     isDisabled: () => false,
@@ -274,7 +275,9 @@ const updateAssignees = (e: any, currentIds: any) => {
         },
       )
       .then(() => {
-        setNotificationView({ open: true, type: 'success' });
+        if (!props.offSuccessNotification) {
+          setNotificationView({ open: true, type: 'success' });
+        }
         emits('refresh');
       })
       .catch(() => (assignessid.value = currentIds));

--- a/src/components/selects/SelectWatchers.vue
+++ b/src/components/selects/SelectWatchers.vue
@@ -147,6 +147,7 @@ const props = withDefaults(
     isLoading?: boolean;
     debounced?: boolean;
     isSprint?: boolean;
+    offSuccessNotification?: boolean;
   }>(),
   {
     isDisabled: () => false,
@@ -300,7 +301,9 @@ const updateProjectWatchers = async (e: any) => {
         },
       )
       .then(() => {
-        setNotificationView({ open: true, type: 'success' });
+        if (!props.offSuccessNotification) {
+          setNotificationView({ open: true, type: 'success' });
+        }
         emits('refresh');
       })
       .catch(() => (watcherid.value = currentIds));
@@ -330,7 +333,9 @@ const updateDocWatchers = async (e: any) => {
       props.docId as string,
     )
     .then(() => {
-      setNotificationView({ open: true, type: 'success' });
+      if (!props.offSuccessNotification) {
+        setNotificationView({ open: true, type: 'success' });
+      }
       emits('refresh');
     });
 };
@@ -338,7 +343,7 @@ const updateDocWatchers = async (e: any) => {
 const updateSprintWatchers = (e: any) => {
   emits('update:watchers', e);
   return;
-}
+};
 
 const handleUpdateWatchers = async (e) => {
   watcherid.value = e;

--- a/src/composables/useStatusSelect.ts
+++ b/src/composables/useStatusSelect.ts
@@ -12,7 +12,7 @@ import {
   NotUpdated,
 } from 'src/modules/sprints/stores/sprint-store';
 
-export function useStatusSelect() {
+export function useStatusSelect(offSuccessNotification?: boolean) {
   const { currentWorkspaceSlug } = storeToRefs(useWorkspaceStore());
   const singleIssueStore = useSingleIssueStore();
   const sprintStore = useSprintStore();
@@ -71,6 +71,9 @@ export function useStatusSelect() {
 
     sprintStore.triggerSprintRefresh(NotUpdated.SprintPage);
     resetItems();
+
+    if (offSuccessNotification) return;
+
     setNotificationView({ open: true, type: 'success' });
   };
 

--- a/src/composables/useTusUploader.ts
+++ b/src/composables/useTusUploader.ts
@@ -25,6 +25,7 @@ interface UseUploaderOptions {
     message?: string;
     onClick?: () => void;
   }) => void;
+  offSuccessNotification?: boolean;
 }
 
 export function useTusUploader(options: UseUploaderOptions) {
@@ -50,6 +51,7 @@ export function useTusUploader(options: UseUploaderOptions) {
     message?: string,
     onClick?: () => void,
   ) => {
+    if (options.offSuccessNotification && type === 'success') return;
     options.onNotify?.({ type, message, file, onClick });
   };
 

--- a/src/modules/issue-list/components/IssueTable.vue
+++ b/src/modules/issue-list/components/IssueTable.vue
@@ -201,7 +201,7 @@ const emits = defineEmits<{
   openIssue: [number, DtoIssue];
   updateGroupedIssues: [any];
   tableHide: [string, Record<string, any>];
-  tableShow: [string]
+  tableShow: [string];
 }>();
 
 const {
@@ -328,7 +328,7 @@ const onMiddleScroll = () => {
 
 onMounted(async () => {
   bus.on('updateIssueTable', handleUpdateIssueTable);
-  emits('tableShow', props.entity.id);
+  emits('tableShow', props.entity?.id);
 
   await nextTick();
 
@@ -345,7 +345,7 @@ onMounted(async () => {
 
 onBeforeUnmount(() => {
   bus.off('updateIssueTable', handleUpdateIssueTable);
-  emits('tableHide', props.entity.id, parsePagination(quasarPagination.value));
+  emits('tableHide', props.entity?.id, parsePagination(quasarPagination.value));
   hScroll.value?.removeEventListener('scroll', onHScroll);
   middle?.removeEventListener('scroll', onMiddleScroll);
 });

--- a/src/modules/single-issue/custom-properties/ui/IssueCustomProperties.vue
+++ b/src/modules/single-issue/custom-properties/ui/IssueCustomProperties.vue
@@ -55,11 +55,15 @@
                 url: prop.value?.url,
               }"
               disableDelete
-              @update="isLinkOpenDialog = true; linkToUpdate = {
-                id: prop.id,
-                title: prop.value?.name,
-                url: prop.value?.url,
-              }; propToUpdate = prop"
+              @update="
+                isLinkOpenDialog = true;
+                linkToUpdate = {
+                  id: prop.id,
+                  title: prop.value?.name,
+                  url: prop.value?.url,
+                };
+                propToUpdate = prop;
+              "
             />
           </div>
 
@@ -123,6 +127,7 @@ import LinkDialog from 'src/components/dialogs/LinkDialog.vue';
 const props = defineProps<{
   projectId: string;
   issueId: string;
+  offSuccessNotification?: boolean;
 }>();
 
 //stores
@@ -162,15 +167,20 @@ const updateValue = async (prop: DtoIssueProperty, newValue: any) => {
       props.projectId,
       props.issueId,
       prop.template_id as string,
-      prop.type === 'link' ? { url: newValue.url, name: newValue.title } : newValue,
+      prop.type === 'link'
+        ? { url: newValue.url, name: newValue.title }
+        : newValue,
     );
-    setNotificationView({
-      open: true,
-      type: 'success',
-      customMessage: 'Параметр сохранен',
-    });
+    if (!props.offSuccessNotification) {
+      setNotificationView({
+        open: true,
+        type: 'success',
+        customMessage: 'Параметр сохранен',
+      });
+    }
+
     if (prop.type === 'link') {
-      fetchData()
+      fetchData();
     }
   } catch (e) {
     console.error(e);

--- a/src/modules/single-issue/linked-issues/ui/LinkedIssuesPanel.vue
+++ b/src/modules/single-issue/linked-issues/ui/LinkedIssuesPanel.vue
@@ -66,7 +66,6 @@ import { useRolesStore } from 'stores/roles-store';
 import { useProjectStore } from 'src/stores/project-store';
 import { useWorkspaceStore } from 'src/stores/workspace-store';
 import { useSingleIssueStore } from 'src/stores/single-issue-store';
-import { useNotificationStore } from 'src/stores/notification-store';
 
 // components
 import SelectIssueDialog from 'src/components/dialogs/IssueDialogs/SelectIssueDialog.vue';
@@ -100,7 +99,6 @@ const projectStore = useProjectStore();
 const workspaceStore = useWorkspaceStore();
 const singleIssueStore = useSingleIssueStore();
 const { hasPermissionByIssue } = useRolesStore();
-const { setNotificationView } = useNotificationStore();
 
 const bus = inject('bus') as EventBus;
 
@@ -126,13 +124,7 @@ const handleSaveLinkedIssues = async (ids: string[], type?: string) => {
     props.project_detail?.id ?? currentProjectID.value,
     currentIssueID.value,
     { issue_ids: ids },
-  ).then(() => {
-    setNotificationView({
-      type: 'success',
-      open: true,
-      customMessage: type === 'save' ? 'Связь добавлена' : 'Связь удалена',
-    });
-  });
+  );
 
   await refresh();
 };

--- a/src/modules/single-issue/main-issue-info/ui/IssueTagsDialog.vue
+++ b/src/modules/single-issue/main-issue-info/ui/IssueTagsDialog.vue
@@ -217,7 +217,6 @@ const handleAddTag = (newTag: ITag | DtoLabelLight) => {
       )
       .then(() => {
         refresh();
-        setNotificationView({ type: 'success', open: true });
         emits('refresh');
       });
   } else {
@@ -267,7 +266,6 @@ const handleSaveTags = () => {
       },
     )
     .then(() => {
-      setNotificationView({ type: 'success', open: true });
       emits('refresh');
     })
     .finally(() => emits('close'));

--- a/src/modules/single-issue/main-issue-info/ui/MainIssueInfo.vue
+++ b/src/modules/single-issue/main-issue-info/ui/MainIssueInfo.vue
@@ -204,7 +204,6 @@ import AvatarImage from 'src/components/AvatarImage.vue';
 
 // directives
 import ClickOutside from 'src/directives/click-outside';
-import { useNotificationStore } from 'stores/notification-store';
 import IssueNameInput from './IssueNameInput.vue';
 import IssueDescriptionEditor from './IssueDescriptionEditor.vue';
 
@@ -241,7 +240,6 @@ const workspaceStore = useWorkspaceStore();
 const { user } = storeToRefs(userStore);
 const { currentProjectID, project } = storeToRefs(projectStore);
 const { issueData, currentIssueID } = storeToRefs(singleIssueStore);
-const { setNotificationView } = useNotificationStore();
 const { currentWorkspaceSlug } = storeToRefs(workspaceStore);
 
 // vars
@@ -340,11 +338,6 @@ const handleUpdateTitleAndEditor = async () => {
       if (issueData.value) {
         issueData.value.description_html = initialIssueDescription.value;
       }
-
-      setNotificationView({
-        open: true,
-        type: 'success',
-      });
       emits('update:issuePage');
     })
     .catch(() => {

--- a/src/modules/single-issue/preview-issue/ui/IssuePreview.vue
+++ b/src/modules/single-issue/preview-issue/ui/IssuePreview.vue
@@ -70,6 +70,7 @@
 
       <SelectAttachments
         entityType="issue"
+        off-success-notification
         :is-edit="hasPermissionByIssue(issueData, 'change-issue-secondary')"
         :delete-attachment-func="deleteAttachment"
         :get-attachment-func="getAttachmentsList"

--- a/src/modules/single-issue/sub-issues/ui/AddSubIssueButton.vue
+++ b/src/modules/single-issue/sub-issues/ui/AddSubIssueButton.vue
@@ -35,16 +35,12 @@ import { toRefs, ref, inject } from 'vue';
 import { useRoute } from 'vue-router';
 import { storeToRefs } from 'pinia';
 // stores
-import { useNotificationStore } from 'src/stores/notification-store';
 import { useProjectStore } from 'src/stores/project-store';
 
 // components
 import AddIcon from 'src/components/icons/AddIcon.vue';
 import NewIssueDialog from 'src/components/NewIssueDialog.vue';
 import SelectIssueDialog from 'src/components/dialogs/IssueDialogs/SelectIssueDialog.vue';
-
-// constants
-import { SUCCESS_ADD_SUBISSUE } from 'src/constants/notifications';
 
 // interfaces
 import { IIssueSelectRequest } from 'src/interfaces/issues';
@@ -62,7 +58,6 @@ const props = defineProps<{
 const emits = defineEmits<{ refresh: [] }>();
 
 const $q = useQuasar();
-const { setNotificationView } = useNotificationStore();
 const projectStore = useProjectStore();
 const singleIssueStore = useSingleIssueStore();
 const route = useRoute();
@@ -81,11 +76,6 @@ const addIssue = (items: Array<string>) => {
     currentIssueID.value as string,
     items,
   ).then(() => {
-    setNotificationView({
-      open: true,
-      type: 'success',
-      customMessage: SUCCESS_ADD_SUBISSUE,
-    });
     emits('refresh');
   });
 };
@@ -97,13 +87,12 @@ const addNewIssue = () => {
       parent: parentId.value,
       projectid: props.projectid,
       project: props.project,
+      offSuccessNotification: true,
     },
   }).onOk(() => emits('refresh'));
 };
 
 const onRequest = async (params: IIssueSelectRequest) => {
-  console.log(props.project);
-  console.log(props.projectid);
   if (!props.projectid) return;
   getAvailableSubIssues(
     route.params.workspace as string,

--- a/src/modules/single-issue/sub-issues/ui/SubIssues.vue
+++ b/src/modules/single-issue/sub-issues/ui/SubIssues.vue
@@ -85,11 +85,9 @@ import { computed } from 'vue';
 import { useUserStore } from 'src/stores/user-store';
 import { useRolesStore } from 'src/stores/roles-store';
 import { useSingleIssueStore } from 'src/stores/single-issue-store';
-import { useNotificationStore } from 'src/stores/notification-store';
 // api
 import { updateIssueInfo } from '../../services/api';
 import { moveSubIssueDown, moveSubIssueUp } from '../services/api';
-import { SUCCESS_DELETE_SUBISSUE } from 'src/constants/notifications';
 import {
   DtoIssue,
   DtoProject,
@@ -98,7 +96,6 @@ import {
 const userStore = useUserStore();
 const singleIssueStore = useSingleIssueStore();
 const { hasPermissionByIssue } = useRolesStore();
-const { setNotificationView } = useNotificationStore();
 const { issueData, currentIssueID } = storeToRefs(singleIssueStore);
 const { user } = storeToRefs(userStore);
 
@@ -153,12 +150,6 @@ const removeChild = (id: string) => {
       parent: null,
     },
   ).then(() => {
-    setNotificationView({
-      type: 'success',
-      open: true,
-      customMessage: SUCCESS_DELETE_SUBISSUE,
-    });
-
     emits('refresh');
   });
 };

--- a/src/modules/single-issue/ui/IssuePanel.vue
+++ b/src/modules/single-issue/ui/IssuePanel.vue
@@ -26,6 +26,7 @@
         <LinkedIssuesPanel />
 
         <SelectAttachments
+          off-success-notification
           entityType="issue"
           :is-edit="hasPermissionByIssue(issueData, 'change-issue-secondary')"
           :delete-attachment-func="deleteAttachment"

--- a/src/modules/sprints/stores/sprint-store.ts
+++ b/src/modules/sprints/stores/sprint-store.ts
@@ -189,7 +189,6 @@ export const useSprintStore = defineStore('sprint-store', {
     },
 
     async getSprintsList(wsSlug: string) {
-      // return this.sprintsList = await getSprintList(wsSlug)
       return await sprintApi
         .getSprintList(wsSlug)
         .then((res) => (this.sprintsList = res.data));

--- a/src/shared/components/file-uploader/FileUploaderCard.vue
+++ b/src/shared/components/file-uploader/FileUploaderCard.vue
@@ -58,11 +58,7 @@
                 <HintTooltip>Скопировать ссылку</HintTooltip>
               </q-btn>
               <q-btn
-                v-if="
-                  !progress &&
-                  !status &&
-                  (!file.draft || downloadHandler)
-                "
+                v-if="!progress && !status && (!file.draft || downloadHandler)"
                 unelevated
                 dense
                 @click="handleDownload()"
@@ -209,6 +205,7 @@ interface IProps {
     file: IAttachmentCard,
     onProgress: (progress: number) => void,
   ) => Promise<void>;
+  offSuccessNotification?: boolean;
 }
 
 const props = defineProps<IProps>();
@@ -236,11 +233,14 @@ const handleDownload = async () => {
       await props.downloadHandler(props.file, (progress) => {
         internalProgress.value = progress;
       });
-      setNotificationView({
-        type: 'success',
-        open: true,
-        customMessage: SUCCESS_DOWNLOAD_FILE,
-      });
+      if (!props.offSuccessNotification) {
+        setNotificationView({
+          type: 'success',
+          open: true,
+          customMessage: SUCCESS_DOWNLOAD_FILE,
+        });
+      }
+
       return;
     }
 
@@ -256,11 +256,14 @@ const handleDownload = async () => {
           },
         },
       );
-      setNotificationView({
-        type: 'success',
-        open: true,
-        customMessage: SUCCESS_DOWNLOAD_FILE,
-      });
+      if (!props.offSuccessNotification) {
+        setNotificationView({
+          type: 'success',
+          open: true,
+          customMessage: SUCCESS_DOWNLOAD_FILE,
+        });
+      }
+
       return data;
     }, props.file.asset.name);
   } finally {


### PR DESCRIPTION
В компонентах, которые относятся только к превью или странице задачи удалены успешные уведомления
В компонентах, которые используются в других местах, добавлен флаг для отмены успешных уведомлений
