### PR TITLE
fix: исправлена ошибка при редактировании формы без даты окончания BUGS-1281

### DIFF
--- a/src/components/forms/dialogs/FormDialog.vue
+++ b/src/components/forms/dialogs/FormDialog.vue
@@ -301,7 +301,7 @@ const save = async () => {
   });
 };
 
-const validateDate = (val: string) => {
+const validateDate = (val: string | null) => {
   const minD = validDate(val);
   return minD;
 };

--- a/src/components/forms/helper/helperForm.ts
+++ b/src/components/forms/helper/helperForm.ts
@@ -71,8 +71,8 @@ export const minDate = (date: string) => {
   return date >= dayjs(new Date()).format('YYYY/MM/DD');
 };
 
-export const validDate = (date: string): true | string => {
-  if (date?.length === 0) return true;
+export const validDate = (date: string | null): true | string => {
+  if (!date || date?.length === 0) return true;
 
   const parts = date.split('.');
   if (parts.length !== 3) return 'Некорректная дата';


### PR DESCRIPTION
настоящая ошибка была в хелпере validDate, функция используется для формирования rules в инпуте даты, а она падала на  date.split, потому что не учитывала, что date может быть null