### PR TITLE
fix: изменен лимит выдаваемых пользователей для приглашения в проект BUGS-1292

### DIFF
--- a/src/modules/project-settings/members/ui/MembersProjectSettings.vue
+++ b/src/modules/project-settings/members/ui/MembersProjectSettings.vue
@@ -343,7 +343,7 @@ async function refresh() {
   await workspaceStore
     .getWorkspaceMembers(currentWorkspaceSlug.value as string, {
       offset: 0,
-      limit: 100,
+      limit: 1000,
     })
     .then((res) => (wsMembers.value = res?.result ?? []));
 
@@ -362,6 +362,7 @@ async function onSuccess(msg?: string) {
   emits('update');
 }
 
+// TODO Убрать, вместо него смотреть на props.row?.workspace_admin
 const isAdminWs = (member_id: string) => {
   return (
     wsMembers.value?.find((member) => member_id === member.member_id)?.role ===

--- a/src/modules/project-settings/members/ui/MembersProjectSettings.vue
+++ b/src/modules/project-settings/members/ui/MembersProjectSettings.vue
@@ -343,7 +343,7 @@ async function refresh() {
   await workspaceStore
     .getWorkspaceMembers(currentWorkspaceSlug.value as string, {
       offset: 0,
-      limit: -1,
+      limit: 100,
     })
     .then((res) => (wsMembers.value = res?.result ?? []));
 


### PR DESCRIPTION
В лимите для отображения списка пользователей стоял -1, который функцией воспринимался как 1, из-за чего выдавался только 1 пользователь. 
По дефолту в описании функции стоит 100, выставил 100.