### PR TITLE
fix: убрана ошибочная очистка списка спринтов в меню BUGS-1294

### DIFF
--- a/src/components/menu/NavSprints.vue
+++ b/src/components/menu/NavSprints.vue
@@ -219,13 +219,6 @@ watch(
     }
   },
 );
-
-watch(() => currentWorkspaceSlug.value,
-  () => {
-    sprintStore.clearSprintsList();
-  },
-  { immediate: true }
-)
 </script>
 
 <style lang="scss" scoped>


### PR DESCRIPTION
Удален устаревший watcher в NavSprints.vue, который при каждом монтировании компонента принудительно вызывал sprintStore.clearSprintsList(). 

 BUGS-1294